### PR TITLE
fix: Protect mem consumption from null deref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ samples/workload/include/**
 
 tests/unit/runtime-common/wasm-apps/main.aot
 tests/unit/aot-stack-frame/wasm-apps/test_aot.h
+.worktrees/

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -966,6 +966,7 @@ memories_deinstantiate(AOTModuleInstance *module_inst)
         }
     }
     wasm_runtime_free(module_inst->memories);
+    module_inst->memories = NULL;
 }
 
 static AOTMemoryInstance *
@@ -3795,12 +3796,31 @@ aot_get_module_mem_consumption(const AOTModule *module,
     mem_conspn->total_size += mem_conspn->aot_code_size;
 }
 
+/**
+ * Calculate memory consumption of an AOT module instance.
+ *
+ * @param module_inst pointer to a fully initialized AOT module instance
+ * @param mem_conspn output structure to store memory consumption details
+ *
+ * @pre module_inst != NULL
+ * @pre module_inst->module != NULL
+ * @pre module_inst->e != NULL
+ * @pre (module_inst->memory_count == 0) || (module_inst->memories != NULL)
+ *
+ * In debug builds, these preconditions are validated with bh_assert.
+ * In release builds, violating preconditions results in undefined behavior.
+ */
 void
 aot_get_module_inst_mem_consumption(const AOTModuleInstance *module_inst,
                                     WASMModuleInstMemConsumption *mem_conspn)
 {
     AOTTableInstance *tbl_inst;
     uint32 i;
+
+    bh_assert(module_inst);
+    bh_assert(module_inst->module);
+    bh_assert(module_inst->e);
+    bh_assert(!module_inst->memory_count || module_inst->memories);
 
     memset(mem_conspn, 0, sizeof(*mem_conspn));
 

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -3445,9 +3445,11 @@ wasm_deinstantiate(WASMModuleInstance *module_inst, bool is_sub_inst)
         (WASMModuleInstanceCommon *)module_inst);
 #endif
 
-    if (module_inst->memory_count > 0)
+    if (module_inst->memory_count > 0) {
         memories_deinstantiate(module_inst, module_inst->memories,
                                module_inst->memory_count);
+        module_inst->memories = NULL;
+    }
 
     if (module_inst->import_func_ptrs) {
         wasm_runtime_free(module_inst->import_func_ptrs);
@@ -4227,12 +4229,31 @@ wasm_get_module_mem_consumption(const WASMModule *module,
     mem_conspn->total_size += mem_conspn->const_strs_size;
 }
 
+/**
+ * Calculate memory consumption of a WASM module instance.
+ *
+ * @param module_inst pointer to a fully initialized WASM module instance
+ * @param mem_conspn output structure to store memory consumption details
+ *
+ * @pre module_inst != NULL
+ * @pre module_inst->module != NULL
+ * @pre module_inst->e != NULL
+ * @pre (module_inst->memory_count == 0) || (module_inst->memories != NULL)
+ *
+ * In debug builds, these preconditions are validated with bh_assert.
+ * In release builds, violating preconditions results in undefined behavior.
+ */
 void
 wasm_get_module_inst_mem_consumption(const WASMModuleInstance *module_inst,
                                      WASMModuleInstMemConsumption *mem_conspn)
 {
     uint32 i;
     uint64 size;
+
+    bh_assert(module_inst);
+    bh_assert(module_inst->module);
+    bh_assert(module_inst->e);
+    bh_assert(!module_inst->memory_count || module_inst->memories);
 
     memset(mem_conspn, 0, sizeof(*mem_conspn));
 


### PR DESCRIPTION
- add debug assertions to wasm_get_module_inst_mem_consumption
- add debug assertions to aot_get_module_inst_mem_consumption
- nullify memories pointer after free in destruction path
- nullify memories pointer after free in AOT destruction
- docs: add precondition documentation for memory consumption functions