### PR TITLE
iwasm: ignore SIGPIPE

### DIFF
--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -452,7 +452,7 @@ module_destroyer_callback(uint8 *buffer, uint32 size)
 #endif /* WASM_ENABLE_MULTI_MODULE */
 
 static int
-init_ignore_sigpipe()
+init_ignore_sigpipe(void)
 {
     struct sigaction sig_act;
     sig_act.sa_handler = SIG_IGN;

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -451,6 +451,18 @@ module_destroyer_callback(uint8 *buffer, uint32 size)
 }
 #endif /* WASM_ENABLE_MULTI_MODULE */
 
+static int
+init_ignore_sigpipe()
+{
+    struct sigaction sig_act;
+    sig_act.sa_handler = SIG_IGN;
+
+    if (sigaction(SIGPIPE, &sig_act, NULL)) {
+        return -1;
+    }
+    return 0;
+}
+
 #if WASM_ENABLE_GLOBAL_HEAP_POOL != 0
 static char global_heap_buf[WASM_GLOBAL_HEAP_SIZE] = { 0 };
 #else
@@ -897,6 +909,9 @@ main(int argc, char *argv[])
         printf("Init runtime environment failed.\n");
         return -1;
     }
+
+    /* set SIGPIPE handler to ignore */
+    init_ignore_sigpipe();
 
 #if WASM_ENABLE_LOG != 0
     bh_log_set_verbose_level(log_verbose_level);


### PR DESCRIPTION
`SIGPIPE` is triggered when writing to a stream that has no readers. Its default behavior is to terminate the application.

- `SIGPIPE`'s rationale was to allow filter programs to exit even if the output of `write` was never checked. It's not relevant in wasm since we're not writing lazy scripts in C anymore, and libraries typically handle errors graciously.
- `EPIPE` is sufficient to tell users of `write` that the function failed
- [the sockets proposal](https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/Posix-compatibility.md#writing-to-closed-streams-sigpipe-so_nosigpipe-) encourages ignoring this signal
- wasm has no concept of signals, so there is ultimately no 'correct' handling of `SIGPIPE`. It should just not affect wasm modules
- currently there are no workarounds like `SO_NOSIGPIPE` or `MSG_NOSIGNAL`

This PR ignores SIGPIPE ~~outright~~ *in product-mini/iwasm* because that's the cleanest way to do it.