### PR TITLE
validate poll_oneoff in/out arrays against nsubscriptions

### DIFF
--- a/core/iwasm/libraries/libc-uvwasi/libc_uvwasi_wrapper.c
+++ b/core/iwasm/libraries/libc-uvwasi/libc_uvwasi_wrapper.c
@@ -932,9 +932,11 @@ wasi_poll_oneoff(wasm_exec_env_t exec_env, const wasi_subscription_t *in,
     if (!uvwasi)
         return (wasi_errno_t)-1;
 
-    if (!validate_native_addr((void *)in, (uint64)sizeof(wasi_subscription_t))
-        || !validate_native_addr(out, (uint64)sizeof(wasi_event_t))
-        || !validate_native_addr(nevents_app, (uint64)sizeof(uint32)))
+    if (!validate_native_addr(nevents_app, (uint64)sizeof(uint32))
+        || !validate_native_addr((void *)in, (uint64)sizeof(wasi_subscription_t)
+                                                 * nsubscriptions)
+        || !validate_native_addr(out,
+                                 (uint64)sizeof(wasi_event_t) * nsubscriptions))
         return (wasi_errno_t)-1;
 
     err = uvwasi_poll_oneoff(uvwasi, in, out, nsubscriptions, &nevents);

--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -1098,9 +1098,11 @@ wasi_poll_oneoff(wasm_exec_env_t exec_env, const wasi_subscription_t *in,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    if (!validate_native_addr((void *)in, (uint64)sizeof(wasi_subscription_t))
-        || !validate_native_addr(out, (uint64)sizeof(wasi_event_t))
-        || !validate_native_addr(nevents_app, (uint64)sizeof(uint32)))
+    if (!validate_native_addr(nevents_app, (uint64)sizeof(uint32))
+        || !validate_native_addr((void *)in, (uint64)sizeof(wasi_subscription_t)
+                                                 * nsubscriptions)
+        || !validate_native_addr(out,
+                                 (uint64)sizeof(wasi_event_t) * nsubscriptions))
         return (wasi_errno_t)-1;
 
 #if WASM_ENABLE_THREAD_MGR == 0


### PR DESCRIPTION
1. wasi_poll_oneoff validates a single wasi_subscription_t at `in` and a single wasi_event_t at `out`, then hands the wasm-controlled `nsubscriptions` to the poll backend, which reads in[0..nsubscriptions) and writes out[0..nevents).
2. when a module points `in`/`out` near the end of its linear memory and passes nsubscriptions > 1, the trailing elements fall outside the validated range; on builds where hardware bounds checks are off and validate_native_addr is the active guard, that becomes an out-of-bounds read and write of memory next to the sandbox.
3. validate the whole `in` and `out` arrays (sizeof * nsubscriptions), the way fd_read/fd_write/sock_recv already validate their iovec arrays. the libc-uvwasi wrapper carried the identical one-element check and gets the same fix.

Checked with hardware bounds checks disabled so validate_native_addr is the active guard: before the change, a module calling poll_oneoff with `in`/`out` one element from the page end and nsubscriptions=2 segfaults; after, the call returns an error and a normal single-subscription poll still returns 0.
