### PR TITLE
Prefer OptionalPassInfoMixin

### DIFF
--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -86,7 +86,12 @@ LLVM_C_EXTERN_C_END
 
 ExitOnError ExitOnErr;
 
-class ExpandMemoryOpPass : public PassInfoMixin<ExpandMemoryOpPass>
+class ExpandMemoryOpPass
+#if LLVM_VERSION_MAJOR >= 23
+    : public OptionalPassInfoMixin<ExpandMemoryOpPass>
+#else
+    : public PassInfoMixin<ExpandMemoryOpPass>
+#endif
 {
   public:
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -88,9 +88,9 @@ ExitOnError ExitOnErr;
 
 class ExpandMemoryOpPass
 #if LLVM_VERSION_MAJOR >= 23
-    : public OptionalPassInfoMixin<ExpandMemoryOpPass>
+  : public OptionalPassInfoMixin<ExpandMemoryOpPass>
 #else
-    : public PassInfoMixin<ExpandMemoryOpPass>
+  : public PassInfoMixin<ExpandMemoryOpPass>
 #endif
 {
   public:


### PR DESCRIPTION
LLVM 23 prefers {Optional,Required}PassInfoMixin rather than PassInfoMixin and explicitly (or not) setting isRequired. In LLVM 24, PassInfoMixin will be moved to a detail namespace and thus will cause a compilation failure.