### PR TITLE
Fix zephyr clock cycles to ns

### DIFF
--- a/core/shared/platform/zephyr/zephyr_clock.c
+++ b/core/shared/platform/zephyr/zephyr_clock.c
@@ -55,9 +55,9 @@ os_clock_time_get(__wasi_clockid_t clock_id, __wasi_timestamp_t precision,
         case __WASI_CLOCK_REALTIME:
         case __WASI_CLOCK_MONOTONIC:
 #ifdef CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
-            *time = k_cycle_get_64();
+            *time = k_cyc_to_ns_near64(k_cycle_get_64());
 #else
-            *time = k_cycle_get_32();
+            *time = k_cyc_to_ns_near64(k_cycle_get_32());
 #endif
             return __WASI_ESUCCESS;
         default:


### PR DESCRIPTION
WASI expects the monotonic/realtime clock in nanoseconds, but k_cycle_get_32/64() returns a raw hardware cycle count.
In my case, returning the raw count made the guest clock run at cycles/1e9 of the real rate (about 0.24x at 240 MHz).
Use k_cyc_to_ns_near64() so the reported time is correct.

Fixes #5023 