### PR TITLE
ci: restrict push-triggered CI to forks via the gate job

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Skip pushes to the maintainer branches (main, release/**, dev/**);
-    # upstream coverage comes from the nightly cron below. Fork feature
-    # branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -73,14 +74,16 @@ jobs:
     #   - schedule: upstream only (the nightly scan of the canonical repo).
     #   - review:   upstream, first approval, only if the pipeline changed.
     #   - dispatch: anywhere, for manual runs on either repo.
+    # The gate decides push / review / dispatch; only the schedule case, which
+    # must stay upstream-only, is spelled out here.
     needs: gate
     if: >-
       !cancelled() &&
       (
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'push' && github.repository != 'wasm-micro-runtime/wasm-micro-runtime') ||
-        (github.event_name == 'schedule' && github.repository == 'wasm-micro-runtime/wasm-micro-runtime') ||
-        (github.event_name == 'pull_request_review' && needs.gate.outputs.run == 'true')
+        github.event_name == 'schedule'
+          && github.repository == 'wasm-micro-runtime/wasm-micro-runtime'
+        || github.event_name != 'schedule'
+          && needs.gate.outputs.run == 'true'
       )
     name: Analyze
     # Runner size impacts CodeQL analysis time. To learn more, please see:

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -6,10 +6,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Never run upstream CI on the maintainer branches: pushes to main,
-    # release/** and dev/** are skipped here (they are covered by the
-    # approval-gated PR review below). Fork feature branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -37,8 +38,8 @@ env:
   PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
 jobs:
-  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
-  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
+  # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
@@ -49,7 +50,7 @@ jobs:
 
   compliance_job:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - name: checkout

--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Never run upstream CI on the maintainer branches: pushes to main,
-    # release/** and dev/** are skipped here (they are covered by the
-    # approval-gated PR review below). Fork feature branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -71,8 +72,8 @@ permissions:
   contents: read
 
 jobs:
-  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
-  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
+  # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
@@ -83,7 +84,7 @@ jobs:
 
   check_version_h:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: write
@@ -91,7 +92,7 @@ jobs:
 
   build_llvm_libraries_on_ubuntu_2204:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Never run upstream CI on the maintainer branches: pushes to main,
-    # release/** and dev/** are skipped here (they are covered by the
-    # approval-gated PR review below). Fork feature branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -57,8 +58,8 @@ permissions:
   contents: read
 
 jobs:
-  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
-  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
+  # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
@@ -68,7 +69,7 @@ jobs:
     uses: ./.github/workflows/gate.yml
   build_llvm_libraries_on_intel_macos:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: write
@@ -78,7 +79,7 @@ jobs:
       arch: "X86"
   build_llvm_libraries_on_arm_macos:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Never run upstream CI on the maintainer branches: pushes to main,
-    # release/** and dev/** are skipped here (they are covered by the
-    # approval-gated PR review below). Fork feature branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -53,8 +54,8 @@ permissions:
   contents: read
 
 jobs:
-  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
-  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
+  # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
@@ -68,7 +69,7 @@ jobs:
   # instead of every leg compiling bloaty and its protobuf/abseil submodules.
   build_bloaty:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Restore or seed the bloaty cache

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Never run upstream CI on the maintainer branches: pushes to main,
-    # release/** and dev/** are skipped here (they are covered by the
-    # approval-gated PR review below). Fork feature branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -60,8 +61,8 @@ permissions:
   contents: read
 
 jobs:
-  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
-  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
+  # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
@@ -71,7 +72,7 @@ jobs:
     uses: ./.github/workflows/gate.yml
   build_llvm_libraries:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: write
@@ -82,7 +83,7 @@ jobs:
 
   build_iwasm:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Never run upstream CI on the maintainer branches: pushes to main,
-    # release/** and dev/** are skipped here (they are covered by the
-    # approval-gated PR review below). Fork feature branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -56,8 +57,8 @@ permissions:
   contents: read
 
 jobs:
-  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
-  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
+  # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
@@ -67,7 +68,7 @@ jobs:
     uses: ./.github/workflows/gate.yml
   build_llvm_libraries_on_windows:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: write
@@ -78,7 +79,7 @@ jobs:
 
   build_iwasm:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: windows-2022
     strategy:
       matrix:

--- a/.github/workflows/compilation_on_zephyr.yml
+++ b/.github/workflows/compilation_on_zephyr.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Never run upstream CI on the maintainer branches: pushes to main,
-    # release/** and dev/** are skipped here (they are covered by the
-    # approval-gated PR review below). Fork feature branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -53,8 +54,8 @@ permissions:
   contents: read
 
 jobs:
-  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
-  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
+  # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
@@ -64,7 +65,7 @@ jobs:
     uses: ./.github/workflows/gate.yml
   smoke_test:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Reusable gate shared by every upstream CI workflow. Callers invoke it via
-# `uses:` on a pull_request_review event and gate their real jobs on
-# `needs.gate.outputs.run`. It runs only for the FIRST approval of a PR and
-# only when the PR touches the caller workflow's push.paths (the path filter
-# pull_request_review lacks, re-applied via pr_touches_paths.py).
+# `uses:` and gate their real jobs on `needs.gate.outputs.run`. Per event:
+#   - push: runs only on a fork, so upstream never spends minutes on a plain
+#     push; contributors still get CI on their own fork's branches.
+#   - pull_request_review: runs only for the FIRST approval of a PR and only
+#     when the PR touches the caller workflow's push.paths (the path filter
+#     pull_request_review lacks, re-applied via pr_touches_paths.py).
+#   - anything else (e.g. workflow_dispatch, schedule): always runs.
 name: gate
 
 on:
@@ -49,6 +52,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -e
+          # Push CI belongs to forks only: upstream pushes are covered by the
+          # approval-gated review path below.
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "run=${{ github.event.repository.fork }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" != "pull_request_review" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "${{ github.event.review.state }}" != "approved" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/hadolint_dockerfiles.yml
+++ b/.github/workflows/hadolint_dockerfiles.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Never run upstream CI on the maintainer branches: pushes to main,
-    # release/** and dev/** are skipped here (they are covered by the
-    # approval-gated PR review below). Fork feature branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -41,8 +42,8 @@ env:
   PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
 jobs:
-  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
-  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
+  # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
@@ -52,7 +53,7 @@ jobs:
     uses: ./.github/workflows/gate.yml
   run-hadolint-on-dockerfiles:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Skip pushes to the maintainer branches (main, release/**, dev/**);
-    # upstream coverage comes from the nightly cron below. Fork feature
-    # branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -78,7 +79,7 @@ jobs:
 
   build_llvm_libraries_on_ubuntu:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: write
@@ -370,7 +371,7 @@ jobs:
 
   build_iwasm_linux_gcc4_8:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: ubuntu-22.04
     container:
       image: ubuntu:14.04
@@ -710,7 +711,7 @@ jobs:
 
   addr2line_tests_multi_sdk:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: ubuntu-22.04
     steps:
       - name: checkout

--- a/.github/workflows/spec_test_on_nuttx.yml
+++ b/.github/workflows/spec_test_on_nuttx.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Never run upstream CI on the maintainer branches: pushes to main,
-    # release/** and dev/** are skipped here (they are covered by the
-    # approval-gated PR review below). Fork feature branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -48,8 +49,8 @@ permissions:
   contents: read
 
 jobs:
-  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
-  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
+  # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
@@ -59,7 +60,7 @@ jobs:
     uses: ./.github/workflows/gate.yml
   build_llvm_libraries:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: write
@@ -71,7 +72,7 @@ jobs:
 
   build_llvm_libraries_xtensa:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/wamr_wasi_extensions.yml
+++ b/.github/workflows/wamr_wasi_extensions.yml
@@ -7,10 +7,11 @@ on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
   # pushes a branch to their fork.
   push:
-    # Never run upstream CI on the maintainer branches: pushes to main,
-    # release/** and dev/** are skipped here (they are covered by the
-    # approval-gated PR review below). Fork feature branches still run.
-    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # Upstream pushes never reach the jobs anyway (the gate job returns
+    # run=false unless the repository is a fork), so this filter only trims a
+    # fork's mirrored copies of the maintainer branches - re-pushing main,
+    # release/** or dev/** to a fork is a sync, not work worth building.
+    # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
@@ -40,8 +41,8 @@ env:
   PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
 jobs:
-  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
-  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
+  # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
@@ -51,7 +52,7 @@ jobs:
     uses: ./.github/workflows/gate.yml
   build_wamr_wasi_extensions:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Move all per-event decisions into the reusable gate workflow: push runs only when the repository is a fork, pull_request_review keeps the first-approval plus path filter, and every other event (dispatch, schedule) runs. Callers now just check needs.gate.outputs.run, and codeql.yml drops its own fork check, keeping only the upstream-only schedule case.