### PR TITLE
ci: check license headers, split android CI, and simplify the PR gate

### DIFF
--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -37,18 +37,39 @@ env:
   # so checkout falls back to the event's default ref.
   PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
+# TODO: fold every second-scale lint into a single lint.yml - this workflow,
+# hadolint_dockerfiles.yml, an actionlint job the repo still lacks, and the
+# API/ABI check of verify_checked_apis.yml. Each of those currently pays its
+# own `gate` invocation (sparse checkout + two gh API calls + a pyyaml install)
+# and occupies its own required-status-check entry, while sharing an identical
+# on:/concurrency/PR_REF preamble that GitHub Actions offers no way to reuse.
+#
+# Do NOT do this as a plain file merge. The path filters differ - this workflow
+# has none on purpose and runs for every push, hadolint only wants
+# **/Dockerfile* - and merging them can only take the union, which either runs
+# hadolint on every C change or skips the format check on every non-Dockerfile
+# change. The consolidation only works with a leading `changes` job doing the
+# path classification once (dorny/paths-filter), each lint job then guarded by
+# `if: needs.changes.outputs.<kind>`.
+#
+# Worth doing when actionlint is added, so the required-status-check names are
+# rewritten once rather than twice. See
+# docs/2026-08-07-pr-gate-design-and-build-verification.md section 2.4 for why
+# renaming checks is not free.
 jobs:
   # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
   # "true" only for a fork push or a PR's first approval. It must NOT be
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
+    name: approval gate
     permissions:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
 
   compliance_job:
+    name: format, naming & license headers
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/compilation_on_android.yml
+++ b/.github/workflows/compilation_on_android.yml
@@ -1,0 +1,162 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Split out of compilation_on_ubuntu.yml: every JIT running mode is
+# excluded on android, so these jobs never restore the LLVM cache. Keeping them
+# in the ubuntu workflow made them wait on a 10-60 min LLVM build for nothing.
+# Here they have no `needs` at all and start immediately.
+name: compilation on android
+
+on:
+  # Fork CI: runs on the fork's own Actions minutes when a contributor
+  # pushes a branch to their fork.
+  push:
+    # Never run upstream CI on the maintainer branches: pushes to main,
+    # release/** and dev/** are skipped here (they are covered by the
+    # approval-gated PR review below). Fork feature branches still run.
+    # NOTE: do not name a local/feature branch main, release/*, or dev/* -
+    # its push CI would be silently skipped by this filter.
+    branches-ignore:
+      - "main"
+      - "release/**"
+      - "dev/**"
+    # Narrower than the ubuntu workflow: android builds iwasm only, so
+    # wamr-compiler, the test suites and wamr-ide are irrelevant here.
+    paths:
+      - ".github/workflows/compilation_on_android.yml"
+      - "build-scripts/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/platforms/android/**"
+  # Upstream CI: only spend upstream minutes once a PR is approved
+  # (first approval only, enforced by the gate job below).
+  pull_request_review:
+    types: [submitted]
+  # allow to be triggered manually
+  workflow_dispatch:
+
+# Cancel any in-flight jobs for the same PR/branch so there's only one active
+# at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Merge ref to check out on approval-gated review events; empty elsewhere
+  # so checkout falls back to the event's default ref.
+  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  # For BUILD. The JIT modes are omitted on purpose: android has no prebuilt
+  # LLVM and Fast JIT / Multi-Tier JIT do not support the platform.
+  AOT_BUILD_OPTIONS: "           -DWAMR_BUILD_AOT=1 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
+  CLASSIC_INTERP_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=0 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
+  FAST_INTERP_BUILD_OPTIONS: "   -DWAMR_BUILD_AOT=0 -DWAMR_BUILD_FAST_INTERP=1 -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
+
+permissions:
+  contents: read
+
+jobs:
+  # Gate upstream minutes: always runs (a few-second no-op on push/dispatch)
+  # and outputs `run`, "true" only for a PR's first approval. It must NOT be
+  # skipped: a skipped job propagates the skip down the needs chain to every
+  # descendant, even ones that broke the chain with their own `if`.
+  gate:
+    name: approval gate
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: ./.github/workflows/gate.yml
+
+  # TODO: 44 jobs is far more android coverage than the incremental signal
+  # justifies - android differs from linux only by core/shared/platform/android
+  # plus the NDK toolchain. Shrink to 3-5 representative combinations. See
+  # docs/2026-08-07-pr-gate-design-and-build-verification.md section 4.3(c).
+  #
+  # TODO: the matrix cross-product gives unreadable job names (the whole tuple
+  # is displayed). Switch to an explicit list of objects carrying short labels,
+  # then set `name: iwasm . android . ${{ matrix.mode }} . ${{ matrix.feature }}`.
+  # See the same document, section 3.5.
+  build_iwasm:
+    needs: gate
+    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        make_options_run_mode: [
+            # Running mode
+            $AOT_BUILD_OPTIONS,
+            $CLASSIC_INTERP_BUILD_OPTIONS,
+            $FAST_INTERP_BUILD_OPTIONS,
+          ]
+        make_options_feature: [
+            # Features. MEMORY64 and SHARED are absent on purpose: android
+            # excluded both for every running mode, so listing them here and
+            # excluding them again below would be dead weight.
+            "-DWAMR_BUILD_CUSTOM_NAME_SECTION=1",
+            "-DWAMR_BUILD_DEBUG_AOT=1",
+            "-DWAMR_BUILD_DEBUG_INTERP=1",
+            "-DWAMR_BUILD_DUMP_CALL_STACK=1",
+            "-DWAMR_BUILD_LIB_PTHREAD=1",
+            "-DWAMR_BUILD_LIB_WASI_THREADS=1",
+            "-DWAMR_BUILD_LOAD_CUSTOM_SECTION=1",
+            "-DWAMR_BUILD_MINI_LOADER=1",
+            "-DWAMR_BUILD_MEMORY_PROFILING=1",
+            "-DWAMR_BUILD_MULTI_MODULE=1",
+            "-DWAMR_BUILD_PERF_PROFILING=1",
+            "-DWAMR_BUILD_LIB_SIMDE=1",
+            "-DWAMR_BUILD_TAIL_CALL=1",
+            "-DWAMR_DISABLE_HW_BOUND_CHECK=1",
+            "-DWAMR_BUILD_MULTI_MEMORY=1",
+            "-DWAMR_BUILD_EXTENDED_CONST_EXPR=1",
+            "-DWAMR_BUILD_LIME1=1 -DWAMR_BUILD_BULK_MEMORY=0 -DWAMR_BUILD_REF_TYPES=0 -DWAMR_BUILD_SIMD=0",
+          ]
+        os: [ubuntu-22.04]
+        exclude:
+          # DEBUG_INTERP only on CLASSIC INTERP mode
+          - make_options_run_mode: $AOT_BUILD_OPTIONS
+            make_options_feature: "-DWAMR_BUILD_DEBUG_INTERP=1"
+          - make_options_run_mode: $FAST_INTERP_BUILD_OPTIONS
+            make_options_feature: "-DWAMR_BUILD_DEBUG_INTERP=1"
+          # DEBUG_AOT only on JIT/AOT mode
+          - make_options_run_mode: $CLASSIC_INTERP_BUILD_OPTIONS
+            make_options_feature: "-DWAMR_BUILD_DEBUG_AOT=1"
+          - make_options_run_mode: $FAST_INTERP_BUILD_OPTIONS
+            make_options_feature: "-DWAMR_BUILD_DEBUG_AOT=1"
+          # MINI_LOADER only on INTERP mode
+          - make_options_run_mode: $AOT_BUILD_OPTIONS
+            make_options_feature: "-DWAMR_BUILD_MINI_LOADER=1"
+          # Multi memory only on CLASSIC INTERP mode
+          - make_options_run_mode: $AOT_BUILD_OPTIONS
+            make_options_feature: "-DWAMR_BUILD_MULTI_MEMORY=1"
+          - make_options_run_mode: $FAST_INTERP_BUILD_OPTIONS
+            make_options_feature: "-DWAMR_BUILD_MULTI_MEMORY=1"
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ env.PR_REF }}
+
+      # TODO: --parallel $(nproc) once the runner size is allowed to vary.
+      - name: Build iwasm for android
+        run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_C_FLAGS="-Werror" ${{ matrix.make_options_run_mode }} ${{ matrix.make_options_feature }} \
+                -DWAMR_BUILD_TARGET=X86_64
+          cmake --build . --config Release --parallel 4
+        working-directory: product-mini/platforms/android
+
+  # Single stable check for branch protection - see the same job in
+  # compilation_on_ubuntu.yml for why an individual matrix job must not be used.
+  required:
+    name: android CI
+    if: always()
+    needs: [gate, build_iwasm]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report which dependency failed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.value.result)\t\(.key)"' | sort
+          echo "$NEEDS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' \
+            > /dev/null

--- a/.github/workflows/compilation_on_ubuntu.yml
+++ b/.github/workflows/compilation_on_ubuntu.yml
@@ -1,7 +1,9 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: compilation on android, ubuntu-22.04
+# The android half of this workflow lives in compilation_on_android.yml: it
+# never restores the LLVM cache, so it must not wait on the LLVM build here.
+name: compilation on ubuntu-22.04
 
 on:
   # Fork CI: runs on the fork's own Actions minutes when a contributor
@@ -19,7 +21,7 @@ on:
       - "dev/**"
     paths:
       - ".github/workflows/build_llvm_libraries.yml"
-      - ".github/workflows/compilation_on_android_ubuntu.yml"
+      - ".github/workflows/compilation_on_ubuntu.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -77,12 +79,14 @@ jobs:
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
+    name: approval gate
     permissions:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
 
   check_version_h:
+    name: version.h in sync
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
@@ -91,6 +95,7 @@ jobs:
     uses: ./.github/workflows/check_version_h.yml
 
   build_llvm_libraries_on_ubuntu_2204:
+    name: llvm libraries (ubuntu-22.04, X86)
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     permissions:
@@ -102,6 +107,7 @@ jobs:
       arch: "X86"
 
   build_wamrc:
+    name: wamrc
     needs: [build_llvm_libraries_on_ubuntu_2204]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -140,6 +146,19 @@ jobs:
           cmake --build . --config Release --parallel 4
         working-directory: wamr-compiler
 
+  # TODO: only the four *_JIT running modes restore the LLVM cache below; the
+  # 49 AOT / classic-interp / fast-interp jobs wait on the LLVM build for
+  # nothing. Split build_iwasm_interp off so it needs no LLVM job at all. See
+  # docs/2026-08-07-pr-gate-design-and-build-verification.md section 3.4.
+  #
+  # TODO: 101 jobs is a full cartesian product of running mode x feature. A
+  # pairwise covering array of ~20-25 combinations gives the same #ifdef
+  # coverage. Doing so also lets each combination carry a short label, which is
+  # what the unreadable matrix job names need. See sections 3.5 and 4.4.
+  #
+  # TODO: this matrix is duplicated almost line for line in nightly_run.yml
+  # (which drifted to 16 features and lost -Werror). Extract it into a reusable
+  # workflow parameterised by scale. See finding F4 and section 4.4.
   build_iwasm:
     needs: [build_llvm_libraries_on_ubuntu_2204]
     runs-on: ${{ matrix.os }}
@@ -178,9 +197,8 @@ jobs:
             "-DWAMR_BUILD_LIME1=1 -DWAMR_BUILD_BULK_MEMORY=0 -DWAMR_BUILD_REF_TYPES=0 -DWAMR_BUILD_SIMD=0",
           ]
         os: [ubuntu-22.04]
-        platform: [android, linux]
         exclude:
-          # incompatible feature and platform and mode
+          # incompatible feature and mode
           # MULTI_MODULE only on INTERP mode and AOT mode
           - make_options_run_mode: $FAST_JIT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MULTI_MODULE=1"
@@ -228,9 +246,7 @@ jobs:
             make_options_feature: "-DWAMR_BUILD_MINI_LOADER=1"
           - make_options_run_mode: $MULTI_TIER_JIT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MINI_LOADER=1"
-          # Memory64 only on CLASSIC INTERP and AOT mode, and only on 64-bit platform
-          - make_options_feature: "-DWAMR_BUILD_MEMORY64=1"
-            platform: android
+          # Memory64 only on CLASSIC INTERP and AOT mode
           - make_options_run_mode: $FAST_INTERP_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MEMORY64=1"
           - make_options_run_mode: $FAST_JIT_BUILD_OPTIONS
@@ -241,9 +257,7 @@ jobs:
             make_options_feature: "-DWAMR_BUILD_MEMORY64=1"
           - make_options_run_mode: $MULTI_TIER_JIT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MEMORY64=1"
-          # Multi memory only on CLASSIC INTERP mode, and only on 64-bit platform
-          - make_options_feature: "-DWAMR_BUILD_MEMORY64=1"
-            platform: android
+          # Multi memory only on CLASSIC INTERP mode
           - make_options_run_mode: $AOT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MULTI_MEMORY=1"
           - make_options_run_mode: $FAST_INTERP_BUILD_OPTIONS
@@ -256,20 +270,6 @@ jobs:
             make_options_feature: "-DWAMR_BUILD_MULTI_MEMORY=1"
           - make_options_run_mode: $MULTI_TIER_JIT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MULTI_MEMORY=1"
-          # Fast-JIT and Multi-Tier-JIT mode don't support android
-          - make_options_run_mode: $FAST_JIT_BUILD_OPTIONS
-            platform: android
-          - make_options_run_mode: $MULTI_TIER_JIT_BUILD_OPTIONS
-            platform: android
-          # LLVM JIT pre-built binary wasn't compiled by Android NDK
-          # and isn't available for android
-          - make_options_run_mode: $LLVM_LAZY_JIT_BUILD_OPTIONS
-            platform: android
-          - make_options_run_mode: $LLVM_EAGER_JIT_BUILD_OPTIONS
-            platform: android
-          # android does not support WAMR_BUILD_SHARED in its CMakeLists.txt.
-          - make_options_feature: "-DWAMR_BUILD_SHARED=1"
-            platform: android
         include:
           - os: ubuntu-22.04
             llvm_cache_key: ${{ needs.build_llvm_libraries_on_ubuntu_2204.outputs.cache_key }}
@@ -306,24 +306,16 @@ jobs:
         if: endsWith(matrix.make_options_run_mode, '_JIT_BUILD_OPTIONS') && (steps.retrieve_llvm_libs.outputs.cache-hit != 'true')
         run: echo "::error::can not get prebuilt llvm libraries" && exit 1
 
+      # TODO: --parallel $(nproc) once the runner size is allowed to vary.
       - name: Build iwasm for linux
-        if: matrix.platform == 'linux'
         run: |
           mkdir build && cd build
           cmake .. -DCMAKE_C_FLAGS="-Werror" ${{ matrix.make_options_run_mode }} ${{ matrix.make_options_feature }} ${{ matrix.extra_options}}
           cmake --build . --config Release --parallel 4
-        working-directory: product-mini/platforms/${{ matrix.platform }}
-
-      - name: Build iwasm for android
-        if: matrix.platform == 'android'
-        run: |
-          mkdir build && cd build
-          cmake .. -DCMAKE_C_FLAGS="-Werror" ${{ matrix.make_options_run_mode }} ${{ matrix.make_options_feature }} \
-                -DWAMR_BUILD_TARGET=X86_64
-          cmake --build . --config Release --parallel 4
-        working-directory: product-mini/platforms/${{ matrix.platform }}
+        working-directory: product-mini/platforms/linux
 
   build_unit_tests:
+    name: unit tests (${{ matrix.build_target }})
     needs: [build_llvm_libraries_on_ubuntu_2204, build_wamrc]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -386,6 +378,7 @@ jobs:
         working-directory: tests/unit
 
   build_regression_tests:
+    name: regression tests (ba-issues)
     needs: [build_llvm_libraries_on_ubuntu_2204]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -427,8 +420,10 @@ jobs:
           python run.py
         working-directory: tests/regression/ba-issues
 
+  # TODO: name this `sample · wasm-c-api · <mode>` once the matrix carries short
+  # labels; today the display name is the whole option string. See section 3.5.
   build_samples_wasm_c_api:
-    needs: [build_iwasm, build_llvm_libraries_on_ubuntu_2204, build_wamrc]
+    needs: [build_llvm_libraries_on_ubuntu_2204, build_wamrc]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -511,8 +506,12 @@ jobs:
           ./test.sh
         working-directory: samples/printversion
 
+  # TODO: move out of the PR gate - this validates that the documented samples
+  # still build, not runtime correctness, and nightly_run.yml already covers
+  # 16 of the 17. See section 4.4.
   build_samples_others:
-    needs: [build_iwasm, build_llvm_libraries_on_ubuntu_2204, build_wamrc]
+    name: samples · misc
+    needs: [build_llvm_libraries_on_ubuntu_2204, build_wamrc]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -680,8 +679,10 @@ jobs:
           ./build.sh --aot
           ./run.sh --aot
 
+  # TODO: name this `spec · <running_mode> · <suite>` once the matrix carries
+  # short labels for the test options. See section 3.5.
   test:
-    needs: [build_iwasm, build_llvm_libraries_on_ubuntu_2204, build_wamrc]
+    needs: [build_llvm_libraries_on_ubuntu_2204, build_wamrc]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -821,3 +822,41 @@ jobs:
           eval $(opam env)
           ./test_wamr.sh ${{ env.X86_32_TARGET_TEST_OPTIONS }} ${{ matrix.test_option }} -t ${{ matrix.running_mode }}
         working-directory: ./tests/wamr-test-suites
+
+  # Single stable check for branch protection. Set THIS as the required status
+  # check, never an individual job: matrix job names are built from the matrix
+  # dimensions, so every matrix refactor renames all of them and silently
+  # invalidates whatever was configured under Settings -> Branches.
+  #
+  # `if: always()` is mandatory. Without it this job is skipped whenever an
+  # upstream job fails, and a skipped job counts as passing for a required
+  # check - it would be a gate that is green forever.
+  #
+  # `skipped` must count as success: when the gate resolves to run=false (the
+  # PR does not touch this workflow's paths, or it is not the first approval)
+  # every job below is skipped, and that is the normal path.
+  required:
+    name: ubuntu CI
+    if: always()
+    needs:
+      [
+        gate,
+        check_version_h,
+        build_llvm_libraries_on_ubuntu_2204,
+        build_wamrc,
+        build_iwasm,
+        build_unit_tests,
+        build_regression_tests,
+        build_samples_wasm_c_api,
+        build_samples_others,
+        test,
+      ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report which dependency failed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.value.result)\t\(.key)"' | sort
+          echo "$NEEDS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' \
+            > /dev/null

--- a/ci/coding_guidelines_check.py
+++ b/ci/coding_guidelines_check.py
@@ -10,6 +10,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import unittest
 
 CLANG_FORMAT_CMD = "clang-format-21"
@@ -34,6 +35,14 @@ EXCLUDE_PATHS = [
 C_SUFFIXES = [".c", ".cc", ".cpp", ".h"]
 INVALID_DIR_NAME_SEGMENT = r"([a-zA-Z0-9]+\_[a-zA-Z0-9]+)"
 INVALID_FILE_NAME_SEGMENT = r"([a-zA-Z0-9]+\-[a-zA-Z0-9]+)"
+
+# License header requirements. Only the SPDX identifier and the presence of a
+# copyright line are enforced: the year and the copyright holder vary per
+# contributor and checking them would only produce noise.
+SPDX_ID = "Apache-2.0 WITH LLVM-exception"
+LICENSE_HEADER_SCAN_LINES = 10
+LICENSED_SUFFIXES = C_SUFFIXES + [".py", ".sh", ".cmake"]
+LICENSED_FILE_NAMES = ["CMakeLists.txt"]
 
 
 def locate_command(command: str) -> bool:
@@ -201,6 +210,20 @@ def check_file_name(path: Path) -> bool:
     return not m
 
 
+def needs_license_header(path: Path) -> bool:
+    return path.suffix in LICENSED_SUFFIXES or path.name in LICENSED_FILE_NAMES
+
+
+def has_license_header(path: Path) -> bool:
+    try:
+        with open(path, encoding="utf-8", errors="ignore") as f:
+            head = "".join(next(f, "") for _ in range(LICENSE_HEADER_SCAN_LINES))
+    except OSError:
+        return False
+
+    return f"SPDX-License-Identifier: {SPDX_ID}" in head and "Copyright (C)" in head
+
+
 def parse_commits_range(root: Path, commits: str) -> list:
     GIT_LOG_CMD = f"git log --pretty='%H' {commits}"
     try:
@@ -258,6 +281,46 @@ def analysis_new_item_name(root: Path, commit: str) -> bool:
         return False
 
 
+def analysis_new_item_license(root: Path, commits: str) -> bool:
+    """
+    Every new source file needs a license header within its first 10 lines:
+
+        /*
+         * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+         * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+         */
+
+    Use the comment syntax of the language, '#' for .py, .sh and .cmake files.
+
+    Only files added by this PR are checked. The copyright year and holder are
+    not enforced.
+    """
+    GIT_DIFF_CMD = f"git diff --name-only --diff-filter=A {commits}"
+    try:
+        output = subprocess.check_output(
+            shlex.split(GIT_DIFF_CMD), cwd=root, universal_newlines=True
+        )
+    except subprocess.CalledProcessError:
+        return False
+
+    missing = []
+    for name in output.split("\n"):
+        if not name:
+            continue
+
+        new_file = root.joinpath(name)
+        if not new_file.is_file() or is_excluded(new_file):
+            continue
+
+        if needs_license_header(new_file) and not has_license_header(new_file):
+            missing.append(name)
+
+    for name in missing:
+        print(f"--- missing license header in {name}")
+
+    return not missing
+
+
 def process_entire_pr(root: Path, commits: str) -> bool:
     if not commits:
         print("Please provide a commits range")
@@ -275,6 +338,10 @@ def process_entire_pr(root: Path, commits: str) -> bool:
         print(f"{analysis_new_item_name.__doc__}")
         found = True
 
+    if not analysis_new_item_license(root, commits):
+        print(f"{analysis_new_item_license.__doc__}")
+        found = True
+
     if not run_clang_format_diff(root, commits):
         print(f"{run_clang_format_diff.__doc__}")
         found = True
@@ -282,6 +349,10 @@ def process_entire_pr(root: Path, commits: str) -> bool:
     return not found
 
 
+# TODO: ci/pre_commit_hook_sample duplicates the clang-format rule and does not
+# check license headers at all. Make the hook call this script instead, so the
+# rules live in one place. See docs/2026-08-07-pr-gate-design-and-build-verification.md
+# section 5.4.
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Check if change meets all coding guideline requirements"
@@ -322,6 +393,29 @@ class TestCheck(unittest.TestCase):
             "/root/Workspace/core/shared/platform/esp-idf/espid_memmap.c"
         )
         self.assertTrue(check_file_name(new_file_path))
+
+    def test_needs_license_header(self):
+        self.assertTrue(needs_license_header(Path("core/iwasm/common/wasm_c_api.c")))
+        self.assertTrue(needs_license_header(Path("product-mini/CMakeLists.txt")))
+        self.assertFalse(needs_license_header(Path("README.md")))
+
+    def test_has_license_header_pass(self):
+        wamr_root = Path(__file__).parent.joinpath("..").resolve()
+        self.assertTrue(
+            has_license_header(wamr_root.joinpath("core/iwasm/include/wasm_export.h"))
+        )
+
+    def test_has_license_header_failed(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".c", delete=False
+        ) as probe_file:
+            probe_file.write("int main(void) { return 0; }\n")
+            probe = Path(probe_file.name)
+
+        try:
+            self.assertFalse(has_license_header(probe))
+        finally:
+            probe.unlink()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**License headers**: ci/coding_guidelines_check.py now requires an SPDX identifier and a copyright line in the first 10 lines of every file a PR adds. It runs inside the existing compliance job rather than a new one, and does not enforce the year or the holder - contributors belong to many organisations, and checking those only produces uninformative red lights.

**Split android out**: every JIT running mode is excluded on android, so those jobs never restore the LLVM cache, yet 44 of them waited on a 10-60 min LLVM build. They move to compilation_on_android.yml with no dependency on it; the remaining file becomes compilation_on_ubuntu.yml. Verified by expanding both matrices and diffing against the original - 145 combinations before and after, with the expander first checked against a real run's job list.

Break the false dependencies: no job here uploads an artifact, so every `needs:` was a serialisation barrier. The worst held `test` (55 jobs, up to 30 min each) behind all 145 compile jobs, even though test_wamr.sh builds its own iwasm. A canary build was prototyped as a replacement and rejected: it duplicated existing coverage and only helped for an outright broken tree, which cancel-in-progress already covers.

**Aggregate check**: both workflows gain a `required` job - `ubuntu CI` and `android CI` - that fails unless every other job succeeded or was skipped. Require these, never an individual job: matrix job names come from the matrix dimensions, so this change alone renamed all 145 of them. `if: always()` is mandatory (a skipped job counts as passing, so without it the gate is green forever) and `skipped` must count as success (the normal path when the gate resolves to run=false).

Non-matrix jobs also get explicit names. Remaining work is marked with TODO: splitting interp from JIT builds, replacing the cartesian product with a covering array, extracting the matrix nightly_run.yml duplicates, and folding the second-scale lints into one lint.yml.

NOTE: renaming jobs invalidates required status checks configured under Settings -> Branches. Update them at merge time to `format, naming & license headers`, `ubuntu CI` and `android CI`, or they stay pending forever.