### PR TITLE
ci: improve nightly run handling

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -77,9 +77,38 @@ jobs:
         .github/workflows/nightly_run.yml
         core/iwasm/libraries/lib-wasi-threads/stress-test/**
 
-  build_llvm_libraries_on_ubuntu:
+  nightly_guard:
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      run: ${{ steps.guard.outputs.run }}
+    steps:
+      - name: Check for an open nightly failure issue
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: nightly_run scheduled failure
+        run: |
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          open_issues=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+            --search "$ISSUE_TITLE in:title" --json title \
+            --jq '[.[] | select(.title == env.ISSUE_TITLE)] | length')
+          if [ "$open_issues" -gt 0 ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build_llvm_libraries_on_ubuntu:
+    needs: nightly_guard
+    if: ${{ !cancelled() && needs.nightly_guard.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: write
@@ -163,7 +192,7 @@ jobs:
             "-DWAMR_BUILD_EXTENDED_CONST_EXPR=1",
           ]
         os: [ubuntu-22.04]
-        platform: [android, linux]
+        platform: [linux]
         exclude:
           # incompatible feature and platform
           # incompatible mode and feature
@@ -214,9 +243,7 @@ jobs:
             make_options_feature: "-DWAMR_BUILD_MINI_LOADER=1"
           - make_options_run_mode: $MULTI_TIER_JIT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MINI_LOADER=1"
-          # Memory64 only on CLASSIC INTERP and AOT mode, and only on 64-bit platform
-          - make_options_feature: "-DWAMR_BUILD_MEMORY64=1"
-            platform: android
+          # Memory64 only on CLASSIC INTERP and AOT mode
           - make_options_run_mode: $FAST_INTERP_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MEMORY64=1"
           - make_options_run_mode: $FAST_JIT_BUILD_OPTIONS
@@ -227,9 +254,7 @@ jobs:
             make_options_feature: "-DWAMR_BUILD_MEMORY64=1"
           - make_options_run_mode: $MULTI_TIER_JIT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MEMORY64=1"
-          # Multi memory only on CLASSIC INTERP mode, and only on 64-bit platform
-          - make_options_feature: "-DWAMR_BUILD_MEMORY64=1"
-            platform: android
+          # Multi memory only on CLASSIC INTERP mode
           - make_options_run_mode: $AOT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MULTI_MEMORY=1"
           - make_options_run_mode: $FAST_INTERP_BUILD_OPTIONS
@@ -242,17 +267,6 @@ jobs:
             make_options_feature: "-DWAMR_BUILD_MULTI_MEMORY=1"
           - make_options_run_mode: $MULTI_TIER_JIT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MULTI_MEMORY=1"
-          # Fast-JIT and Multi-Tier-JIT mode don't support android
-          - make_options_run_mode: $FAST_JIT_BUILD_OPTIONS
-            platform: android
-          - make_options_run_mode: $MULTI_TIER_JIT_BUILD_OPTIONS
-            platform: android
-          # LLVM JIT pre-built binary wasn't compiled by Android NDK
-          # and isn't available for android
-          - make_options_run_mode: $LLVM_LAZY_JIT_BUILD_OPTIONS
-            platform: android
-          - make_options_run_mode: $LLVM_EAGER_JIT_BUILD_OPTIONS
-            platform: android
         include:
           - os: ubuntu-22.04
             llvm_cache_key: ${{ needs.build_llvm_libraries_on_ubuntu.outputs.cache_key }}
@@ -290,25 +304,15 @@ jobs:
         if: endsWith(matrix.make_options_run_mode, '_JIT_BUILD_OPTIONS') && (steps.retrieve_llvm_libs.outputs.cache-hit != 'true')
         run: echo "::error::can not get prebuilt llvm libraries" && exit 1
 
-      - name: Build iwasm for linux
-        if: matrix.platform == 'linux'
+      - name: Build iwasm
         run: |
           mkdir build && cd build
           cmake .. ${{ matrix.make_options_run_mode }} ${{ matrix.make_options_feature }} ${{ matrix.extra_options }}
           cmake --build . --config Release --parallel 4
         working-directory: product-mini/platforms/${{ matrix.platform }}
 
-      - name: Build iwasm for android
-        if: matrix.platform == 'android'
-        run: |
-          mkdir build && cd build
-          cmake .. ${{ matrix.make_options_run_mode }} ${{ matrix.make_options_feature }} ${{ matrix.extra_options }} \
-                -DWAMR_BUILD_TARGET=X86_64
-          cmake --build . --config Release --parallel 4
-        working-directory: product-mini/platforms/${{ matrix.platform }}
-
   build_unit_tests:
-    needs: [build_llvm_libraries_on_ubuntu, build_wamrc]
+    needs: build_llvm_libraries_on_ubuntu
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -370,8 +374,8 @@ jobs:
         working-directory: tests/unit
 
   build_iwasm_linux_gcc4_8:
-    needs: gate
-    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
+    needs: nightly_guard
+    if: ${{ !cancelled() && needs.nightly_guard.outputs.run == 'true' }}
     runs-on: ubuntu-22.04
     container:
       image: ubuntu:14.04
@@ -468,7 +472,7 @@ jobs:
         working-directory: wamr/product-mini/platforms/linux
 
   build_samples_wasm_c_api:
-    needs: [build_iwasm, build_llvm_libraries_on_ubuntu, build_wamrc]
+    needs: build_llvm_libraries_on_ubuntu
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -553,7 +557,7 @@ jobs:
         working-directory: samples/wasm-c-api
 
   build_samples_others:
-    needs: [build_iwasm, build_llvm_libraries_on_ubuntu, build_wamrc]
+    needs: build_llvm_libraries_on_ubuntu
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -571,7 +575,7 @@ jobs:
         uses: ./.github/actions/install-wasi-sdk-wabt
         with:
           os: ${{ matrix.os }}
-        
+
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
         uses: actions/cache@v6
@@ -710,8 +714,8 @@ jobs:
           ./run.sh --aot
 
   addr2line_tests_multi_sdk:
-    needs: gate
-    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
+    needs: nightly_guard
+    if: ${{ !cancelled() && needs.nightly_guard.outputs.run == 'true' }}
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
@@ -751,7 +755,7 @@ jobs:
         run: ./run_tests.sh --multi-sdk -v
 
   test:
-    needs: [build_iwasm, build_llvm_libraries_on_ubuntu, build_wamrc]
+    needs: build_llvm_libraries_on_ubuntu
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -896,3 +900,35 @@ jobs:
         if: env.TEST_ON_X86_32 == 'true'
         run: ./test_wamr.sh ${{ env.X86_32_TARGET_TEST_OPTIONS }} ${{ matrix.test_option }} -t ${{ matrix.running_mode }}
         working-directory: ./tests/wamr-test-suites
+
+  report_failure:
+    needs:
+      - nightly_guard
+      - build_llvm_libraries_on_ubuntu
+      - build_wamrc
+      - build_iwasm
+      - build_unit_tests
+      - build_iwasm_linux_gcc4_8
+      - build_samples_wasm_c_api
+      - build_samples_others
+      - addr2line_tests_multi_sdk
+      - test
+    if: ${{ always() && github.event_name == 'schedule' && needs.nightly_guard.outputs.run == 'true' && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create a nightly failure issue if needed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: nightly_run scheduled failure
+        run: |
+          open_issues=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+            --search "$ISSUE_TITLE in:title" --json title \
+            --jq '[.[] | select(.title == env.ISSUE_TITLE)] | length')
+          if [ "$open_issues" -eq 0 ]; then
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$ISSUE_TITLE" \
+              --body "Scheduled nightly run failed: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          fi


### PR DESCRIPTION
The nightly workflow still builds Android despite this coverage moving elsewhere, allows compiler warnings to pass, serializes jobs without artifact dependencies, and repeats scheduled failures indefinitely.

Remove Android from the iwasm matrix and add -Werror to direct CMake builds so nightly focuses on Linux coverage and rejects new warnings.

Add a scheduled-run guard that checks for an open 'nightly_run scheduled failure' issue before starting the expensive jobs. Scheduled runs now skip the pipeline until the issue is closed, then resume automatically.

Remove ordering-only needs so jobs that only require LLVM can run in parallel after the LLVM build.

Add a final scheduled-failure reporter that creates an issue with the failed run URL only when no matching open issue exists.

---

pass on forked repo. https://github.com/lum1n0us/wasm-micro-runtime/actions/runs/31451282913