### PR TITLE
feat: Raw address mode (WAMR_BUILD_RAW_MEMORY)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ samples/workload/include/**
 
 tests/unit/runtime-common/wasm-apps/main.aot
 tests/unit/aot-stack-frame/wasm-apps/test_aot.h
+
+# Local IDE / clangd
+compile_commands.json
+build-raw-memory-test/

--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -251,6 +251,10 @@ if (NOT DEFINED WAMR_BUILD_MEMORY64)
   set (WAMR_BUILD_MEMORY64 0)
 endif ()
 
+if (NOT DEFINED WAMR_BUILD_RAW_MEMORY)
+  set (WAMR_BUILD_RAW_MEMORY 0)
+endif ()
+
 if (NOT DEFINED WAMR_BUILD_MULTI_MEMORY)
   set (WAMR_BUILD_MULTI_MEMORY 0)
 endif ()
@@ -417,6 +421,12 @@ endif ()
 if (WAMR_BUILD_SHARED_HEAP EQUAL 1)
   add_definitions (-DWASM_ENABLE_SHARED_HEAP=1)
   message ("     Shared heap enabled")
+endif()
+if (WAMR_BUILD_RAW_MEMORY EQUAL 1)
+  # Guest integers are host pointers. Fine on 32- and 64-bit; mem32 on a
+  # 64-bit host still needs pointers that fit in i32 (e.g. MAP_32BIT).
+  add_definitions (-DWASM_ENABLE_RAW_MEMORY=1)
+  message ("     Raw memory (host-pointer addressing) enabled")
 endif()
 if (WAMR_BUILD_COPY_CALL_STACK EQUAL 1)
   add_definitions (-DWASM_ENABLE_COPY_CALL_STACK=1)
@@ -806,6 +816,7 @@ message (
 "       \"Garbage Collection\" via WAMR_BUILD_GC: ${WAMR_BUILD_GC}\n"
 "       \"Legacy Exception Handling\" via WAMR_BUILD_EXCE_HANDLING: ${WAMR_BUILD_EXCE_HANDLING}\n"
 "       \"Memory64\" via WAMR_BUILD_MEMORY64: ${WAMR_BUILD_MEMORY64}\n"
+"       \"Raw Memory\" via WAMR_BUILD_RAW_MEMORY: ${WAMR_BUILD_RAW_MEMORY}\n"
 "       \"Multiple Memories\" via WAMR_BUILD_MULTI_MEMORY: ${WAMR_BUILD_MULTI_MEMORY}\n"
 "       \"Reference Types\" via WAMR_BUILD_REF_TYPES: ${WAMR_BUILD_REF_TYPES}\n"
 "       \"Reference-Typed Strings\" via WAMR_BUILD_STRINGREF: ${WAMR_BUILD_STRINGREF}\n"

--- a/build-scripts/unsupported_combination.cmake
+++ b/build-scripts/unsupported_combination.cmake
@@ -95,6 +95,12 @@ if(WAMR_BUILD_SHARED_HEAP EQUAL 1)
   check_fast_jit_error("Unsupported build configuration: SHARED_HEAP + FAST_JIT")
 endif()
 
+if(WAMR_BUILD_RAW_MEMORY EQUAL 1)
+  if(WAMR_BUILD_SHARED_HEAP EQUAL 1)
+    message(FATAL_ERROR "Unsupported build configuration: RAW_MEMORY + SHARED_HEAP")
+  endif()
+endif()
+
 if(WAMR_BUILD_SIMD EQUAL 1)
   check_classic_interp_error("Unsupported build configuration: SIMD + CLASSIC_INTERP")
   check_fast_jit_error("Unsupported build configuration: SIMD + FAST_JIT")

--- a/core/config.h
+++ b/core/config.h
@@ -720,6 +720,11 @@ unless used elsewhere */
 #define WASM_ENABLE_SHARED_HEAP 0
 #endif
 
+/* Disable raw (host-pointer) address mode by default */
+#ifndef WASM_ENABLE_RAW_MEMORY
+#define WASM_ENABLE_RAW_MEMORY 0
+#endif
+
 #ifndef WASM_ENABLE_SHRUNK_MEMORY
 #define WASM_ENABLE_SHRUNK_MEMORY 1
 #endif

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -3046,6 +3046,22 @@ aot_module_malloc_internal(AOTModuleInstance *module_inst,
     uint8 *addr = NULL;
     uint64 offset = 0;
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(
+            (WASMModuleInstanceCommon *)module_inst)) {
+        addr = wasm_runtime_raw_malloc((WASMModuleInstanceCommon *)module_inst,
+                                      size);
+        if (!addr) {
+            LOG_WARNING("warning: allocate %" PRIu64 " bytes memory failed",
+                        size);
+            return 0;
+        }
+        if (p_native_addr)
+            *p_native_addr = addr;
+        return (uint64)(uintptr_t)addr;
+    }
+#endif
+
     /* TODO: Memory64 size check based on memory idx type */
     bh_assert(size <= UINT32_MAX);
 
@@ -3107,6 +3123,21 @@ aot_module_realloc_internal(AOTModuleInstance *module_inst,
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
     uint8 *addr = NULL;
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(
+            (WASMModuleInstanceCommon *)module_inst)) {
+        addr = wasm_runtime_raw_realloc((WASMModuleInstanceCommon *)module_inst,
+                                       (void *)(uintptr_t)ptr, size);
+        if (!addr && size != 0) {
+            aot_set_exception(module_inst, "out of memory");
+            return 0;
+        }
+        if (p_native_addr)
+            *p_native_addr = addr;
+        return (uint64)(uintptr_t)addr;
+    }
+#endif
+
     /* TODO: Memory64 ptr and size check based on memory idx type */
     bh_assert(ptr <= UINT32_MAX);
     bh_assert(size <= UINT32_MAX);
@@ -3148,6 +3179,15 @@ aot_module_free_internal(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
     AOTModule *module = (AOTModule *)module_inst->module;
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(
+            (WASMModuleInstanceCommon *)module_inst)) {
+        wasm_runtime_raw_free((WASMModuleInstanceCommon *)module_inst,
+                              (void *)(uintptr_t)ptr);
+        return;
+    }
+#endif
 
     if (!memory_inst) {
         return;

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -1131,6 +1131,17 @@ wasm_runtime_validate_app_addr(WASMModuleInstanceCommon *module_inst_comm,
     bh_assert(module_inst_comm->module_type == Wasm_Module_Bytecode
               || module_inst_comm->module_type == Wasm_Module_AoT);
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(module_inst_comm)) {
+        /* Host pointers are trusted; reject only obvious overflow. */
+        if (size > 0 && app_offset > UINT64_MAX - size) {
+            wasm_set_exception(module_inst, "out of bounds memory access");
+            return false;
+        }
+        return true;
+    }
+#endif
+
     if (!is_bounds_checks_enabled(module_inst_comm)) {
         return true;
     }
@@ -1186,6 +1197,24 @@ wasm_runtime_validate_app_str_addr(WASMModuleInstanceCommon *module_inst_comm,
 
     bh_assert(module_inst_comm->module_type == Wasm_Module_Bytecode
               || module_inst_comm->module_type == Wasm_Module_AoT);
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(module_inst_comm)) {
+        /* Best-effort NUL scan with a soft cap; no linear-memory bound. */
+        str = (char *)(uintptr_t)app_str_offset;
+        if (!str)
+            goto fail_str;
+        str_end = str + (64 * 1024);
+        while (str < str_end && *str != '\0')
+            str++;
+        if (str == str_end)
+            goto fail_str;
+        return true;
+    fail_str:
+        wasm_set_exception(module_inst, "out of bounds memory access");
+        return false;
+    }
+#endif
 
     if (!is_bounds_checks_enabled(module_inst_comm)) {
         return true;
@@ -1250,6 +1279,16 @@ wasm_runtime_validate_native_addr(WASMModuleInstanceCommon *module_inst_comm,
     bh_assert(module_inst_comm->module_type == Wasm_Module_Bytecode
               || module_inst_comm->module_type == Wasm_Module_AoT);
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(module_inst_comm)) {
+        if (size > 0 && (uintptr_t)addr > UINTPTR_MAX - (uintptr_t)size) {
+            wasm_set_exception(module_inst, "out of bounds memory access");
+            return false;
+        }
+        return true;
+    }
+#endif
+
     if (!is_bounds_checks_enabled(module_inst_comm)) {
         return true;
     }
@@ -1302,6 +1341,12 @@ wasm_runtime_addr_app_to_native(WASMModuleInstanceCommon *module_inst_comm,
     bh_assert(module_inst_comm->module_type == Wasm_Module_Bytecode
               || module_inst_comm->module_type == Wasm_Module_AoT);
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(module_inst_comm)) {
+        return (void *)(uintptr_t)app_offset;
+    }
+#endif
+
     bounds_checks = is_bounds_checks_enabled(module_inst_comm);
 
     memory_inst = wasm_get_default_memory(module_inst);
@@ -1348,6 +1393,12 @@ wasm_runtime_addr_native_to_app(WASMModuleInstanceCommon *module_inst_comm,
 
     bh_assert(module_inst_comm->module_type == Wasm_Module_Bytecode
               || module_inst_comm->module_type == Wasm_Module_AoT);
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(module_inst_comm)) {
+        return (uint64)(uintptr_t)native_ptr;
+    }
+#endif
 
     bounds_checks = is_bounds_checks_enabled(module_inst_comm);
 
@@ -1468,6 +1519,15 @@ wasm_check_app_addr_and_convert(WASMModuleInstance *module_inst, bool is_str,
 #endif
 
     bh_assert(app_buf_addr <= UINTPTR_MAX && app_buf_size <= UINTPTR_MAX);
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(
+            (WASMModuleInstanceCommon *)module_inst)) {
+        /* Trusted host pointer — no linear-memory validate. */
+        *p_native_addr = (void *)(uintptr_t)app_buf_addr;
+        return true;
+    }
+#endif
 
     if (!memory_inst) {
         wasm_set_exception(module_inst, "out of bounds memory access");
@@ -2118,3 +2178,128 @@ wasm_allocate_linear_memory(uint8 **data, bool is_shared_memory,
 
     return BHT_OK;
 }
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+static void *
+raw_default_malloc(void *env, size_t size)
+{
+    (void)env;
+    return os_malloc((unsigned)size);
+}
+
+static void
+raw_default_free(void *env, void *ptr)
+{
+    (void)env;
+    os_free(ptr);
+}
+
+static void *
+raw_default_realloc(void *env, void *ptr, size_t size)
+{
+    (void)env;
+    return os_realloc(ptr, (unsigned)size);
+}
+
+static void *
+raw_default_calloc(void *env, size_t nmemb, size_t size)
+{
+    void *p;
+    size_t total;
+
+    (void)env;
+    if (nmemb != 0 && size > SIZE_MAX / nmemb)
+        return NULL;
+    total = nmemb * size;
+    p = os_malloc((unsigned)total);
+    if (p)
+        memset(p, 0, total);
+    return p;
+}
+
+static void
+init_default_raw_hooks(WASMRawAllocHooks *hooks)
+{
+    hooks->malloc_func = raw_default_malloc;
+    hooks->free_func = raw_default_free;
+    hooks->realloc_func = raw_default_realloc;
+    hooks->calloc_func = raw_default_calloc;
+    hooks->env = NULL;
+}
+
+bool
+wasm_runtime_is_raw_address_mode(WASMModuleInstanceCommon *module_inst)
+{
+    WASMModuleInstance *inst;
+
+    if (!module_inst)
+        return false;
+
+    /* Fast-interp handle-table init calls the interpreter with a zeroed
+     * stack module (e == NULL); treat that as sandbox. */
+    inst = (WASMModuleInstance *)module_inst;
+    if (!inst->e)
+        return false;
+
+    return GetModuleInstanceExtraCommon(inst)->address_mode
+           == (uint8)WASM_ADDR_RAW;
+}
+
+void *
+wasm_runtime_raw_malloc(WASMModuleInstanceCommon *module_inst, uint64 size)
+{
+    WASMModuleInstanceExtraCommon *common =
+        GetModuleInstanceExtraCommon((WASMModuleInstance *)module_inst);
+    WASMRawAllocHooks *hooks = &common->raw_alloc_hooks;
+
+    if (!hooks->malloc_func)
+        init_default_raw_hooks(hooks);
+    if (size > SIZE_MAX)
+        return NULL;
+    return hooks->malloc_func(hooks->env, (size_t)size);
+}
+
+void
+wasm_runtime_raw_free(WASMModuleInstanceCommon *module_inst, void *ptr)
+{
+    WASMModuleInstanceExtraCommon *common =
+        GetModuleInstanceExtraCommon((WASMModuleInstance *)module_inst);
+    WASMRawAllocHooks *hooks = &common->raw_alloc_hooks;
+
+    if (!ptr)
+        return;
+    if (!hooks->free_func)
+        init_default_raw_hooks(hooks);
+    hooks->free_func(hooks->env, ptr);
+}
+
+void *
+wasm_runtime_raw_realloc(WASMModuleInstanceCommon *module_inst, void *ptr,
+                         uint64 size)
+{
+    WASMModuleInstanceExtraCommon *common =
+        GetModuleInstanceExtraCommon((WASMModuleInstance *)module_inst);
+    WASMRawAllocHooks *hooks = &common->raw_alloc_hooks;
+
+    if (!hooks->realloc_func)
+        init_default_raw_hooks(hooks);
+    if (size > SIZE_MAX)
+        return NULL;
+    return hooks->realloc_func(hooks->env, ptr, (size_t)size);
+}
+
+void *
+wasm_runtime_raw_calloc(WASMModuleInstanceCommon *module_inst, uint64 nmemb,
+                        uint64 size)
+{
+    WASMModuleInstanceExtraCommon *common =
+        GetModuleInstanceExtraCommon((WASMModuleInstance *)module_inst);
+    WASMRawAllocHooks *hooks = &common->raw_alloc_hooks;
+
+    if (!hooks->calloc_func)
+        init_default_raw_hooks(hooks);
+    if (nmemb > SIZE_MAX || size > SIZE_MAX)
+        return NULL;
+    return hooks->calloc_func(hooks->env, (size_t)nmemb, (size_t)size);
+}
+#endif /* WASM_ENABLE_RAW_MEMORY != 0 */

--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -123,6 +123,51 @@ wasm_runtime_shared_heap_free(WASMModuleInstanceCommon *module_inst,
                               uint64 ptr);
 #endif /* end of WASM_ENABLE_SHARED_HEAP != 0 */
 
+/* Resolve linear native addr; when RAW_MEMORY is on, callers must provide
+ * a bool local `is_raw_address_mode` (set once per interp entry).
+ * `native_addr` is the destination pointer variable (maddr/mdst/msrc/...). */
+#if WASM_ENABLE_RAW_MEMORY != 0
+#define WASM_RESOLVE_LINEAR_MADDR(offset1, native_addr)      \
+    do {                                                     \
+        if (is_raw_address_mode)                             \
+            (native_addr) = (uint8 *)(uintptr_t)(offset1);   \
+        else                                                 \
+            (native_addr) = memory->memory_data + (offset1); \
+    } while (0)
+#define WASM_BOUNDS_OK(cond) (is_raw_address_mode || (cond))
+#else
+#define WASM_RESOLVE_LINEAR_MADDR(offset1, native_addr)      \
+    do {                                                     \
+        (native_addr) = memory->memory_data + (offset1);     \
+    } while (0)
+#define WASM_BOUNDS_OK(cond) (cond)
+#endif
+
+/* HW-bound-check path for bulk ops (memory.fill/copy/init): used when
+ * OS_ENABLE_HW_BOUND_CHECK is defined. Requires locals `memory`,
+ * `linear_mem_size`, and (if RAW) `is_raw_address_mode`, plus `out_of_bounds`. */
+#if WASM_ENABLE_RAW_MEMORY != 0
+#define WASM_RESOLVE_BULK_HW(start, bytes, native_addr)                        \
+    do {                                                                       \
+        if (is_raw_address_mode) {                                             \
+            (native_addr) = (uint8 *)(uintptr_t)(start);                       \
+        }                                                                      \
+        else if ((uint64)(start) + (uint64)(bytes) > linear_mem_size) {        \
+            goto out_of_bounds;                                                \
+        }                                                                      \
+        else {                                                                 \
+            (native_addr) = memory->memory_data + (start);                     \
+        }                                                                      \
+    } while (0)
+#else
+#define WASM_RESOLVE_BULK_HW(start, bytes, native_addr)                        \
+    do {                                                                       \
+        if ((uint64)(start) + (uint64)(bytes) > linear_mem_size)               \
+            goto out_of_bounds;                                                \
+        (native_addr) = memory->memory_data + (start);                         \
+    } while (0)
+#endif
+
 bool
 wasm_runtime_memory_init(mem_alloc_type_t mem_alloc_type,
                          const MemAllocOption *alloc_option);
@@ -149,6 +194,25 @@ wasm_allocate_linear_memory(uint8 **data, bool is_shared_memory,
                             bool is_memory64, uint64 num_bytes_per_page,
                             uint64 init_page_count, uint64 max_page_count,
                             uint64 *memory_data_size);
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+bool
+wasm_runtime_is_raw_address_mode(WASMModuleInstanceCommon *module_inst);
+
+void *
+wasm_runtime_raw_malloc(WASMModuleInstanceCommon *module_inst, uint64 size);
+
+void
+wasm_runtime_raw_free(WASMModuleInstanceCommon *module_inst, void *ptr);
+
+void *
+wasm_runtime_raw_realloc(WASMModuleInstanceCommon *module_inst, void *ptr,
+                         uint64 size);
+
+void *
+wasm_runtime_raw_calloc(WASMModuleInstanceCommon *module_inst, uint64 nmemb,
+                        uint64 size);
+#endif
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -33,6 +33,7 @@
 #endif
 #if WASM_ENABLE_FAST_JIT != 0
 #include "../fast-jit/jit_compiler.h"
+#include "../fast-jit/jit_codecache.h"
 #endif
 #if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
 #include "../compilation/aot_llvm.h"
@@ -3443,6 +3444,166 @@ wasm_runtime_is_bounds_checks_enabled(WASMModuleInstanceCommon *module_inst)
 }
 #endif
 
+bool
+wasm_runtime_set_address_mode(WASMModuleInstanceCommon *module_inst,
+                              wasm_address_mode_t mode)
+{
+#if WASM_ENABLE_RAW_MEMORY == 0
+    (void)module_inst;
+    (void)mode;
+    return false;
+#else
+    WASMModuleInstanceExtraCommon *common;
+    WASMModule *module;
+
+    if (!module_inst
+        || (mode != WASM_ADDR_SANDBOX && mode != WASM_ADDR_RAW)) {
+        return false;
+    }
+
+#if WASM_ENABLE_SHARED_HEAP != 0
+    if (mode == WASM_ADDR_RAW
+        && wasm_runtime_get_shared_heap(module_inst) != NULL) {
+        return false;
+    }
+#endif
+
+    common = GetModuleInstanceExtraCommon((WASMModuleInstance *)module_inst);
+    common->address_mode = (uint8)mode;
+
+    if (mode == WASM_ADDR_RAW) {
+#if WASM_CONFIGURABLE_BOUNDS_CHECKS != 0
+        wasm_runtime_set_bounds_checks(module_inst, false);
+#endif
+    }
+
+    /* Bake into the module so Fast-JIT can specialize at compile time.
+     * Load-time ORC backend threads may already have compiled (or be
+     * compiling) sandbox code; stop them and invalidate before baking. */
+    if (module_inst->module_type == Wasm_Module_Bytecode) {
+        module = ((WASMModuleInstance *)module_inst)->module;
+        if (module) {
+#if WASM_ENABLE_FAST_JIT != 0
+            if (module->address_mode != (uint8)mode
+                && module->fast_jit_func_ptrs) {
+                uint32 i;
+#if WASM_ENABLE_LAZY_JIT != 0
+                JitGlobals *jit_globals = jit_compiler_get_jit_globals();
+                {
+                    uint32 t, thread_num =
+                        (uint32)(sizeof(module->orcjit_threads)
+                                 / sizeof(module->orcjit_threads[0]));
+                    module->orcjit_stop_compiling = true;
+                    for (t = 0; t < thread_num; t++) {
+                        if (module->orcjit_threads[t]) {
+                            os_thread_join(module->orcjit_threads[t], NULL);
+                            /* Avoid double-join on unload. */
+                            memset(&module->orcjit_threads[t], 0,
+                                   sizeof(module->orcjit_threads[t]));
+                        }
+                    }
+                }
+#endif
+                /* Bake mode before invalidating so any recompile is correct. */
+                module->address_mode = (uint8)mode;
+
+                for (i = 0; i < module->function_count; i++) {
+                    uint32 lock_idx = i % WASM_ORC_JIT_BACKEND_THREAD_NUM;
+                    void *jitted;
+
+                    os_mutex_lock(&module->fast_jit_thread_locks[lock_idx]);
+                    jitted = module->functions[i]->fast_jit_jitted_code;
+                    module->functions[i]->fast_jit_jitted_code = NULL;
+                    if (jitted)
+                        jit_code_cache_free(jitted);
+#if WASM_ENABLE_LAZY_JIT != 0
+                    module->fast_jit_func_ptrs[i] =
+                        jit_globals->compile_fast_jit_and_then_call;
+#else
+                    module->fast_jit_func_ptrs[i] = NULL;
+#endif
+                    os_mutex_unlock(&module->fast_jit_thread_locks[lock_idx]);
+                }
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_LAZY_JIT != 0
+                /* Per-instance Fast-JIT tables (multi-tier) must match. */
+                os_mutex_lock(&module->instance_list_lock);
+                {
+                    WASMModuleInstance *inst = module->instance_list;
+                    while (inst) {
+                        if (inst->e->running_mode == Mode_Fast_JIT
+                            && inst->fast_jit_func_ptrs
+                            && inst->fast_jit_func_ptrs
+                                   != module->fast_jit_func_ptrs) {
+                            for (i = 0; i < module->function_count; i++) {
+                                inst->fast_jit_func_ptrs[i] =
+                                    jit_globals->compile_fast_jit_and_then_call;
+                            }
+                        }
+                        inst = inst->e->next;
+                    }
+                }
+                os_mutex_unlock(&module->instance_list_lock);
+#endif
+#if WASM_ENABLE_LAZY_JIT == 0
+                /* Eager Fast-JIT: recompile immediately with the new mode. */
+                if (!jit_compiler_compile_all(module))
+                    return false;
+#endif
+            }
+            else
+#endif /* WASM_ENABLE_FAST_JIT != 0 */
+            {
+                module->address_mode = (uint8)mode;
+            }
+        }
+    }
+
+    return true;
+#endif /* WASM_ENABLE_RAW_MEMORY != 0 */
+}
+
+wasm_address_mode_t
+wasm_runtime_get_address_mode(WASMModuleInstanceCommon *module_inst)
+{
+#if WASM_ENABLE_RAW_MEMORY == 0
+    (void)module_inst;
+    return WASM_ADDR_SANDBOX;
+#else
+    if (!module_inst)
+        return WASM_ADDR_SANDBOX;
+    return (wasm_address_mode_t)GetModuleInstanceExtraCommon(
+                                  (WASMModuleInstance *)module_inst)
+        ->address_mode;
+#endif
+}
+
+bool
+wasm_runtime_set_raw_alloc_hooks(WASMModuleInstanceCommon *module_inst,
+                                 const WASMRawAllocHooks *hooks)
+{
+#if WASM_ENABLE_RAW_MEMORY == 0
+    (void)module_inst;
+    (void)hooks;
+    return false;
+#else
+    WASMModuleInstanceExtraCommon *common;
+
+    if (!module_inst)
+        return false;
+
+    common = GetModuleInstanceExtraCommon((WASMModuleInstance *)module_inst);
+    if (!hooks) {
+        memset(&common->raw_alloc_hooks, 0, sizeof(WASMRawAllocHooks));
+        return true;
+    }
+    if (!hooks->malloc_func || !hooks->free_func || !hooks->realloc_func
+        || !hooks->calloc_func)
+        return false;
+    common->raw_alloc_hooks = *hooks;
+    return true;
+#endif
+}
+
 uint64
 wasm_runtime_module_malloc_internal(WASMModuleInstanceCommon *module_inst,
                                     WASMExecEnv *exec_env, uint64 size,
@@ -4899,6 +5060,27 @@ wasm_runtime_unregister_natives(const char *module_name,
     return wasm_native_unregister_natives(module_name, native_symbols);
 }
 
+
+static bool
+native_arg_from_app_addr(WASMModuleInstanceCommon *module, uint64 app_addr,
+                         uint64 size, bool is_str, uintptr_t *out)
+{
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(module)) {
+        *out = (uintptr_t)app_addr;
+        return true;
+    }
+#endif
+    if (is_str) {
+        if (!wasm_runtime_validate_app_str_addr(module, app_addr))
+            return false;
+    }
+    else if (!wasm_runtime_validate_app_addr(module, app_addr, size))
+        return false;
+    *out = (uintptr_t)wasm_runtime_addr_app_to_native(module, app_addr);
+    return true;
+}
+
 bool
 wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
                                const WASMFuncType *func_type,
@@ -4952,23 +5134,23 @@ wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
                             /* pointer without length followed */
                             ptr_len = 1;
 
-                        if (!wasm_runtime_validate_app_addr(
-                                module, (uint64)arg_i32, (uint64)ptr_len))
-                            goto fail;
-
-                        *(uintptr_t *)argv_dst =
-                            (uintptr_t)wasm_runtime_addr_app_to_native(
-                                module, (uint64)arg_i32);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, (uint64)arg_i32,
+                                                         (uint64)ptr_len, false, &native_p))
+                                goto fail;
+                            *(uintptr_t *)argv_dst = native_p;
+                        }
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
-                        if (!wasm_runtime_validate_app_str_addr(
-                                module, (uint64)arg_i32))
-                            goto fail;
-
-                        *(uintptr_t *)argv_dst =
-                            (uintptr_t)wasm_runtime_addr_app_to_native(
-                                module, (uint64)arg_i32);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, (uint64)arg_i32, 1, true,
+                                                         &native_p))
+                                goto fail;
+                            *(uintptr_t *)argv_dst = native_p;
+                        }
                     }
                 }
                 break;
@@ -4995,21 +5177,23 @@ wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
                             /* pointer without length followed */
                             ptr_len = 1;
 
-                        if (!wasm_runtime_validate_app_addr(module, arg_i64,
-                                                            (uint64)ptr_len))
-                            goto fail;
-
-                        *argv_dst = (uint64)wasm_runtime_addr_app_to_native(
-                            module, arg_i64);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, arg_i64,
+                                                         (uint64)ptr_len, false, &native_p))
+                                goto fail;
+                            *argv_dst = (uint64)native_p;
+                        }
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
-                        if (!wasm_runtime_validate_app_str_addr(module,
-                                                                arg_i64))
-                            goto fail;
-
-                        *argv_dst = (uint64)wasm_runtime_addr_app_to_native(
-                            module, arg_i64);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, arg_i64, 1, true,
+                                                         &native_p))
+                                goto fail;
+                            *argv_dst = (uint64)native_p;
+                        }
                     }
                 }
                 break;
@@ -5435,21 +5619,23 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                             /* pointer without length followed */
                             ptr_len = 1;
 
-                        if (!wasm_runtime_validate_app_addr(
-                                module, (uint64)arg_i32, (uint64)ptr_len))
-                            goto fail;
-
-                        arg_i32 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, (uint64)arg_i32);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, (uint64)arg_i32,
+                                                         (uint64)ptr_len, false, &native_p))
+                                goto fail;
+                            arg_i32 = native_p;
+                        }
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
-                        if (!wasm_runtime_validate_app_str_addr(
-                                module, (uint64)arg_i32))
-                            goto fail;
-
-                        arg_i32 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, (uint64)arg_i32);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, (uint64)arg_i32, 1, true,
+                                                         &native_p))
+                                goto fail;
+                            arg_i32 = native_p;
+                        }
                     }
                 }
 
@@ -5826,21 +6012,23 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                             /* pointer without length followed */
                             ptr_len = 1;
 
-                        if (!wasm_runtime_validate_app_addr(
-                                module, (uint64)arg_i32, (uint64)ptr_len))
-                            goto fail;
-
-                        arg_i32 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, (uint64)arg_i32);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, (uint64)arg_i32,
+                                                         (uint64)ptr_len, false, &native_p))
+                                goto fail;
+                            arg_i32 = native_p;
+                        }
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
-                        if (!wasm_runtime_validate_app_str_addr(
-                                module, (uint64)arg_i32))
-                            goto fail;
-
-                        arg_i32 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, (uint64)arg_i32);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, (uint64)arg_i32, 1, true,
+                                                         &native_p))
+                                goto fail;
+                            arg_i32 = native_p;
+                        }
                     }
                 }
 
@@ -6150,21 +6338,23 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                             /* pointer without length followed */
                             ptr_len = 1;
 
-                        if (!wasm_runtime_validate_app_addr(
-                                module, (uint64)arg_i32, (uint64)ptr_len))
-                            goto fail;
-
-                        arg_i64 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, (uint64)arg_i32);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, (uint64)arg_i32,
+                                                         (uint64)ptr_len, false, &native_p))
+                                goto fail;
+                            arg_i64 = (uint64)native_p;
+                        }
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
-                        if (!wasm_runtime_validate_app_str_addr(
-                                module, (uint64)arg_i32))
-                            goto fail;
-
-                        arg_i64 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, (uint64)arg_i32);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, (uint64)arg_i32, 1, true,
+                                                         &native_p))
+                                goto fail;
+                            arg_i64 = (uint64)native_p;
+                        }
                     }
                 }
                 if (n_ints < MAX_REG_INTS)
@@ -6191,21 +6381,23 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                             /* pointer without length followed */
                             ptr_len = 1;
 
-                        if (!wasm_runtime_validate_app_addr(module, arg_i64,
-                                                            (uint64)ptr_len))
-                            goto fail;
-
-                        arg_i64 = (uint64)wasm_runtime_addr_app_to_native(
-                            module, arg_i64);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, arg_i64,
+                                                         (uint64)ptr_len, false, &native_p))
+                                goto fail;
+                            arg_i64 = (uint64)native_p;
+                        }
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
-                        if (!wasm_runtime_validate_app_str_addr(module,
-                                                                arg_i64))
-                            goto fail;
-
-                        arg_i64 = (uint64)wasm_runtime_addr_app_to_native(
-                            module, arg_i64);
+                        {
+                            uintptr_t native_p;
+                            if (!native_arg_from_app_addr(module, arg_i64, 1, true,
+                                                         &native_p))
+                                goto fail;
+                            arg_i64 = (uint64)native_p;
+                        }
                     }
                 }
                 if (n_ints < MAX_REG_INTS)

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -1597,9 +1597,20 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                         aot_set_last_error("llvm build zextOrBitCast failed.");
                         goto fail;
                     }
-                    if (!check_app_addr_and_convert(
-                            comp_ctx, func_ctx, false, param_values[j],
-                            native_addr_size, &native_addr)) {
+#if WASM_ENABLE_RAW_MEMORY != 0
+                    if (comp_ctx->enable_raw_memory) {
+                        if (!(native_addr = LLVMBuildIntToPtr(
+                                  comp_ctx->builder, param_values[j],
+                                  INT8_PTR_TYPE, "raw_native_addr"))) {
+                            aot_set_last_error("llvm build inttoptr failed.");
+                            goto fail;
+                        }
+                    }
+                    else
+#endif
+                        if (!check_app_addr_and_convert(
+                                comp_ctx, func_ctx, false, param_values[j],
+                                native_addr_size, &native_addr)) {
                         goto fail;
                     }
                     param_values[j] = native_addr;
@@ -1612,9 +1623,20 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                         aot_set_last_error("llvm build zextOrBitCast failed.");
                         goto fail;
                     }
-                    if (!check_app_addr_and_convert(
-                            comp_ctx, func_ctx, true, param_values[j],
-                            native_addr_size, &native_addr)) {
+#if WASM_ENABLE_RAW_MEMORY != 0
+                    if (comp_ctx->enable_raw_memory) {
+                        if (!(native_addr = LLVMBuildIntToPtr(
+                                  comp_ctx->builder, param_values[j],
+                                  INT8_PTR_TYPE, "raw_native_str"))) {
+                            aot_set_last_error("llvm build inttoptr failed.");
+                            goto fail;
+                        }
+                    }
+                    else
+#endif
+                        if (!check_app_addr_and_convert(
+                                comp_ctx, func_ctx, true, param_values[j],
+                                native_addr_size, &native_addr)) {
                         goto fail;
                     }
                     param_values[j] = native_addr;

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -643,6 +643,68 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP_MEM_OFFSET(addr);
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (comp_ctx->enable_raw_memory) {
+        LLVMValueRef addr_u, off_u, sum;
+
+        (void)mem_base_addr;
+        (void)mem_check_bound;
+        (void)block_curr;
+        (void)check_succ;
+        (void)is_local_of_aot_value;
+        (void)is_const;
+        (void)local_idx_of_aot_value;
+        (void)const_value;
+        (void)enable_segue;
+
+        if (is_target_64bit) {
+            if (LLVMTypeOf(addr) != I64_TYPE) {
+                if (!(addr_u = LLVMBuildZExt(comp_ctx->builder, addr, I64_TYPE,
+                                             "raw_addr"))) {
+                    aot_set_last_error("llvm build zext failed.");
+                    goto fail;
+                }
+            }
+            else {
+                addr_u = addr;
+            }
+            if (!(off_u = I64_CONST(offset))) {
+                aot_set_last_error("llvm create const failed.");
+                goto fail;
+            }
+            if (!(sum = LLVMBuildAdd(comp_ctx->builder, addr_u, off_u,
+                                     "raw_sum"))) {
+                aot_set_last_error("llvm build add failed.");
+                goto fail;
+            }
+            if (!(maddr = LLVMBuildIntToPtr(comp_ctx->builder, sum,
+                                            INT8_PTR_TYPE, "maddr"))) {
+                aot_set_last_error("llvm build inttoptr failed.");
+                goto fail;
+            }
+        }
+        else {
+            if (!(off_u = I32_CONST(offset))) {
+                aot_set_last_error("llvm create const failed.");
+                goto fail;
+            }
+            if (!(sum = LLVMBuildAdd(comp_ctx->builder, addr, off_u,
+                                     "raw_sum"))) {
+                aot_set_last_error("llvm build add failed.");
+                goto fail;
+            }
+            if (!(maddr = LLVMBuildIntToPtr(comp_ctx->builder, sum,
+                                            INT8_PTR_TYPE, "maddr"))) {
+                aot_set_last_error("llvm build inttoptr failed.");
+                goto fail;
+            }
+        }
+        if (alignp != NULL)
+            *alignp = 1;
+        return maddr;
+    }
+#endif
+
     /*
      * Note: not throw the integer-overflow-exception here since it must
      * have been thrown when converting float to integer before
@@ -1392,6 +1454,20 @@ aot_compile_op_memory_grow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     LLVMValueRef u32_max, u32_cmp_result;
 #endif
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (comp_ctx->enable_raw_memory) {
+        POP_PAGE_COUNT(delta);
+        (void)delta;
+        (void)mem_size;
+        if (!(ret_value = MEMORY64_COND_VALUE(I64_CONST(-1), I32_CONST(-1)))) {
+            aot_set_last_error("llvm create const failed.");
+            return false;
+        }
+        PUSH_PAGE_COUNT(ret_value);
+        return true;
+    }
+#endif
+
     if (!mem_size)
         return false;
 
@@ -1503,6 +1579,52 @@ check_bulk_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 #endif
 
     is_target_64bit = (comp_ctx->pointer_size == sizeof(uint64)) ? true : false;
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (comp_ctx->enable_raw_memory) {
+        LLVMValueRef addr_u;
+
+        (void)bytes;
+        (void)max_addr;
+        (void)cmp;
+        (void)cmp1;
+        (void)offset1;
+        (void)mem_base_addr;
+        (void)block_curr;
+        (void)check_succ;
+        (void)mem_size;
+        (void)is_memory64;
+#if WASM_ENABLE_SHARED_HEAP != 0
+        (void)maddr_phi;
+        (void)block_maddr_phi;
+#endif
+        if (is_target_64bit) {
+            if (LLVMTypeOf(offset) != I64_TYPE) {
+                if (!(addr_u = LLVMBuildZExt(comp_ctx->builder, offset,
+                                             I64_TYPE, "raw_bulk_addr"))) {
+                    aot_set_last_error("llvm build zext failed.");
+                    return NULL;
+                }
+            }
+            else {
+                addr_u = offset;
+            }
+            if (!(maddr = LLVMBuildIntToPtr(comp_ctx->builder, addr_u,
+                                            INT8_PTR_TYPE, "maddr"))) {
+                aot_set_last_error("llvm build inttoptr failed.");
+                return NULL;
+            }
+        }
+        else {
+            if (!(maddr = LLVMBuildIntToPtr(comp_ctx->builder, offset,
+                                            INT8_PTR_TYPE, "maddr"))) {
+                aot_set_last_error("llvm build inttoptr failed.");
+                return NULL;
+            }
+        }
+        return maddr;
+    }
+#endif
 
     /* Get memory base address and memory data size */
 #if WASM_ENABLE_SHARED_MEMORY != 0

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2814,6 +2814,9 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
     if (option->enable_shared_chain)
         comp_ctx->enable_shared_chain = true;
 
+    if (option->enable_raw_memory)
+        comp_ctx->enable_raw_memory = true;
+
     if (option->enable_extended_const)
         comp_ctx->enable_extended_const = true;
 

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -504,6 +504,7 @@ typedef struct AOTCompContext {
 
     bool enable_shared_heap;
     bool enable_shared_chain;
+    bool enable_raw_memory;
 
     uint32 opt_level;
     uint32 size_level;

--- a/core/iwasm/fast-jit/fe/jit_emit_function.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_function.c
@@ -350,6 +350,17 @@ jit_compile_op_call(JitCompContext *cc, uint32 func_idx, bool tail_call)
             }
 
             if (is_pointer_arg) {
+#if WASM_ENABLE_RAW_MEMORY != 0
+                /* Guest bits are already a host pointer — no convert helper. */
+                if (wasm_module->address_mode == (uint8)WASM_ADDR_RAW) {
+#if UINTPTR_MAX == UINT64_MAX
+                    JitReg native = jit_cc_new_reg_ptr(cc);
+                    GEN_INSN(U32TOI64, native, argvs[i]);
+                    argvs[i] = native;
+#endif
+                    continue;
+                }
+#endif
                 JitReg native_addr_64 = jit_cc_new_reg_I64(cc);
                 /* TODO: Memory64 no need to convert if mem idx type i64 */
                 GEN_INSN(I32TOI64, native_addr_64, func_params[2]);

--- a/core/iwasm/fast-jit/fe/jit_emit_memory.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_memory.c
@@ -9,6 +9,7 @@
 #include "../jit_frontend.h"
 #include "../jit_codegen.h"
 #include "../../interpreter/wasm_runtime.h"
+#include "../../common/wasm_memory.h"
 #include "jit_emit_control.h"
 
 #ifndef OS_ENABLE_HW_BOUND_CHECK
@@ -142,6 +143,23 @@ check_and_seek(JitCompContext *cc, JitReg addr, uint32 offset, uint32 bytes)
     uint32 mem_idx = 0;
 #endif
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    /* Guest addr bits are the host pointer; bake absolute maddr. */
+    if (cc->cur_wasm_module->address_mode == (uint8)WASM_ADDR_RAW) {
+#if UINTPTR_MAX == UINT64_MAX
+        JitReg long_addr = jit_cc_new_reg_I64(cc);
+        GEN_INSN(U32TOI64, long_addr, addr);
+        offset1 = jit_cc_new_reg_I64(cc);
+        GEN_INSN(ADD, offset1, NEW_CONST(I64, offset), long_addr);
+#else
+        offset1 = jit_cc_new_reg_I32(cc);
+        GEN_INSN(ADD, offset1, NEW_CONST(I32, offset), addr);
+#endif
+        (void)bytes;
+        return offset1;
+    }
+#endif
+
 #ifndef OS_ENABLE_HW_BOUND_CHECK
     /* ---------- check ---------- */
     /* 1. shortcut if the memory size is 0 */
@@ -181,6 +199,31 @@ fail:
     return 0;
 }
 
+/* After check_and_seek: sandbox uses (memory_data, offset1); raw uses
+ * (absolute_maddr, 0). Compile-time bake-in — no runtime mode branch. */
+static bool
+prepare_memory_access(JitCompContext *cc, JitReg addr, uint32 offset,
+                      uint32 bytes, JitReg *p_memory_data, JitReg *p_offset1)
+{
+    JitReg offset1 = check_and_seek(cc, addr, offset, bytes);
+    if (!offset1)
+        return false;
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (cc->cur_wasm_module->address_mode == (uint8)WASM_ADDR_RAW) {
+        /* Absolute host pointer as base; const offset must be I32 for
+         * x86-64 codegen (CHECK_KIND on const base/offset). */
+        *p_memory_data = offset1;
+        *p_offset1 = NEW_CONST(I32, 0);
+        return true;
+    }
+#endif
+
+    *p_memory_data = get_memory_data_reg(cc->jit_frame, 0);
+    *p_offset1 = offset1;
+    return true;
+}
+
 #if UINTPTR_MAX == UINT64_MAX
 #define CHECK_ALIGNMENT(offset1)                                       \
     do {                                                               \
@@ -214,8 +257,8 @@ jit_compile_op_i32_load(JitCompContext *cc, uint32 align, uint32 offset,
 
     POP_I32(addr);
 
-    offset1 = check_and_seek(cc, addr, offset, bytes);
-    if (!offset1) {
+    if (!prepare_memory_access(cc, addr, offset, bytes, &memory_data,
+                                 &offset1)) {
         goto fail;
     }
 #if WASM_ENABLE_SHARED_MEMORY != 0
@@ -223,8 +266,6 @@ jit_compile_op_i32_load(JitCompContext *cc, uint32 align, uint32 offset,
         CHECK_ALIGNMENT(offset1);
     }
 #endif
-
-    memory_data = get_memory_data_reg(cc->jit_frame, 0);
 
     value = jit_cc_new_reg_I32(cc);
     switch (bytes) {
@@ -287,8 +328,8 @@ jit_compile_op_i64_load(JitCompContext *cc, uint32 align, uint32 offset,
 
     POP_I32(addr);
 
-    offset1 = check_and_seek(cc, addr, offset, bytes);
-    if (!offset1) {
+    if (!prepare_memory_access(cc, addr, offset, bytes, &memory_data,
+                                 &offset1)) {
         goto fail;
     }
 #if WASM_ENABLE_SHARED_MEMORY != 0
@@ -296,8 +337,6 @@ jit_compile_op_i64_load(JitCompContext *cc, uint32 align, uint32 offset,
         CHECK_ALIGNMENT(offset1);
     }
 #endif
-
-    memory_data = get_memory_data_reg(cc->jit_frame, 0);
 
     value = jit_cc_new_reg_I64(cc);
     switch (bytes) {
@@ -368,12 +407,10 @@ jit_compile_op_f32_load(JitCompContext *cc, uint32 align, uint32 offset)
 
     POP_I32(addr);
 
-    offset1 = check_and_seek(cc, addr, offset, 4);
-    if (!offset1) {
+    if (!prepare_memory_access(cc, addr, offset, 4, &memory_data,
+                                 &offset1)) {
         goto fail;
     }
-
-    memory_data = get_memory_data_reg(cc->jit_frame, 0);
 
     value = jit_cc_new_reg_F32(cc);
     GEN_INSN(LDF32, value, memory_data, offset1);
@@ -391,12 +428,10 @@ jit_compile_op_f64_load(JitCompContext *cc, uint32 align, uint32 offset)
 
     POP_I32(addr);
 
-    offset1 = check_and_seek(cc, addr, offset, 8);
-    if (!offset1) {
+    if (!prepare_memory_access(cc, addr, offset, 8, &memory_data,
+                                 &offset1)) {
         goto fail;
     }
-
-    memory_data = get_memory_data_reg(cc->jit_frame, 0);
 
     value = jit_cc_new_reg_F64(cc);
     GEN_INSN(LDF64, value, memory_data, offset1);
@@ -417,8 +452,8 @@ jit_compile_op_i32_store(JitCompContext *cc, uint32 align, uint32 offset,
     POP_I32(value);
     POP_I32(addr);
 
-    offset1 = check_and_seek(cc, addr, offset, bytes);
-    if (!offset1) {
+    if (!prepare_memory_access(cc, addr, offset, bytes, &memory_data,
+                                 &offset1)) {
         goto fail;
     }
 #if WASM_ENABLE_SHARED_MEMORY != 0
@@ -426,8 +461,6 @@ jit_compile_op_i32_store(JitCompContext *cc, uint32 align, uint32 offset,
         CHECK_ALIGNMENT(offset1);
     }
 #endif
-
-    memory_data = get_memory_data_reg(cc->jit_frame, 0);
 
     switch (bytes) {
         case 1:
@@ -473,8 +506,8 @@ jit_compile_op_i64_store(JitCompContext *cc, uint32 align, uint32 offset,
     POP_I64(value);
     POP_I32(addr);
 
-    offset1 = check_and_seek(cc, addr, offset, bytes);
-    if (!offset1) {
+    if (!prepare_memory_access(cc, addr, offset, bytes, &memory_data,
+                                 &offset1)) {
         goto fail;
     }
 #if WASM_ENABLE_SHARED_MEMORY != 0
@@ -486,8 +519,6 @@ jit_compile_op_i64_store(JitCompContext *cc, uint32 align, uint32 offset,
     if (jit_reg_is_const(value) && bytes < 8) {
         value = NEW_CONST(I32, (int32)jit_cc_get_const_I64(cc, value));
     }
-
-    memory_data = get_memory_data_reg(cc->jit_frame, 0);
 
     switch (bytes) {
         case 1:
@@ -536,12 +567,10 @@ jit_compile_op_f32_store(JitCompContext *cc, uint32 align, uint32 offset)
     POP_F32(value);
     POP_I32(addr);
 
-    offset1 = check_and_seek(cc, addr, offset, 4);
-    if (!offset1) {
+    if (!prepare_memory_access(cc, addr, offset, 4, &memory_data,
+                                 &offset1)) {
         goto fail;
     }
-
-    memory_data = get_memory_data_reg(cc->jit_frame, 0);
 
     GEN_INSN(STF32, value, memory_data, offset1);
 
@@ -558,12 +587,10 @@ jit_compile_op_f64_store(JitCompContext *cc, uint32 align, uint32 offset)
     POP_F64(value);
     POP_I32(addr);
 
-    offset1 = check_and_seek(cc, addr, offset, 8);
-    if (!offset1) {
+    if (!prepare_memory_access(cc, addr, offset, 8, &memory_data,
+                                 &offset1)) {
         goto fail;
     }
-
-    memory_data = get_memory_data_reg(cc->jit_frame, 0);
 
     GEN_INSN(STF64, value, memory_data, offset1);
 
@@ -591,6 +618,17 @@ jit_compile_op_memory_grow(JitCompContext *cc, uint32 mem_idx)
 {
     JitReg grow_res, res;
     JitReg prev_page_count, inc_page_count, args[2];
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (cc->cur_wasm_module->address_mode == (uint8)WASM_ADDR_RAW) {
+        /* memory.grow is unsupported in Raw address mode */
+        POP_I32(inc_page_count);
+        (void)inc_page_count;
+        (void)mem_idx;
+        PUSH_I32(NEW_CONST(I32, (int32)-1));
+        return true;
+    }
+#endif
 
     /* Get current page count as prev_page_count */
     prev_page_count = get_cur_page_count_reg(cc->jit_frame, mem_idx);
@@ -725,6 +763,18 @@ wasm_copy_memory(WASMModuleInstance *inst, uint32 src_mem_idx,
     uint64 src_mem_size, dst_mem_size;
     uint8 *src_addr, *dst_addr;
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(
+            (WASMModuleInstanceCommon *)inst)) {
+        (void)src_mem_idx;
+        (void)dst_mem_idx;
+        src_addr = (uint8 *)(uintptr_t)src_offset;
+        dst_addr = (uint8 *)(uintptr_t)dst_offset;
+        bh_memmove_s(dst_addr, len, src_addr, len);
+        return 0;
+    }
+#endif
+
     src_mem = inst->memories[src_mem_idx];
     dst_mem = inst->memories[dst_mem_idx];
     src_mem_size =
@@ -791,6 +841,16 @@ wasm_fill_memory(WASMModuleInstance *inst, uint32 mem_idx, uint32 len,
     WASMMemoryInstance *mem_inst;
     uint64 mem_size;
     uint8 *dst_addr;
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(
+            (WASMModuleInstanceCommon *)inst)) {
+        (void)mem_idx;
+        dst_addr = (uint8 *)(uintptr_t)dst;
+        memset(dst_addr, (int)val, len);
+        return 0;
+    }
+#endif
 
     mem_inst = inst->memories[mem_idx];
     mem_size = mem_inst->cur_page_count * (uint64)mem_inst->num_bytes_per_page;
@@ -912,13 +972,11 @@ jit_compile_op_atomic_rmw(JitCompContext *cc, uint8 atomic_op, uint8 op_type,
     }
     POP_I32(addr);
 
-    offset1 = check_and_seek(cc, addr, offset, bytes);
-    if (!offset1) {
+    if (!prepare_memory_access(cc, addr, offset, bytes, &memory_data,
+                                 &offset1)) {
         goto fail;
     }
     CHECK_ALIGNMENT(offset1);
-
-    memory_data = get_memory_data_reg(cc->jit_frame, 0);
 
     if (op_type == VALUE_TYPE_I32)
         result = jit_cc_new_reg_I32(cc);
@@ -1017,13 +1075,11 @@ jit_compile_op_atomic_cmpxchg(JitCompContext *cc, uint8 op_type, uint32 align,
     }
     POP_I32(addr);
 
-    offset1 = check_and_seek(cc, addr, offset, bytes);
-    if (!offset1) {
+    if (!prepare_memory_access(cc, addr, offset, bytes, &memory_data,
+                                 &offset1)) {
         goto fail;
     }
     CHECK_ALIGNMENT(offset1);
-
-    memory_data = get_memory_data_reg(cc->jit_frame, 0);
 
     GEN_INSN(MOV, is_i32 ? eax_hreg : rax_hreg, expect);
     switch (bytes) {
@@ -1104,9 +1160,9 @@ jit_compile_op_atomic_wait(JitCompContext *cc, uint8 op_type, uint32 align,
     POP_I32(addr);
 
     // Get referenced address and store it in `maddr`
-    JitReg memory_data = get_memory_data_reg(cc->jit_frame, 0);
-    JitReg offset1 = check_and_seek(cc, addr, offset, bytes);
-    if (!offset1)
+    JitReg memory_data, offset1;
+    if (!prepare_memory_access(cc, addr, offset, bytes, &memory_data,
+                                 &offset1))
         goto fail;
     CHECK_ALIGNMENT(offset1);
 
@@ -1154,9 +1210,9 @@ jit_compiler_op_atomic_notify(JitCompContext *cc, uint32 align, uint32 offset,
     POP_I32(addr);
 
     // Get referenced address and store it in `maddr`
-    JitReg memory_data = get_memory_data_reg(cc->jit_frame, 0);
-    JitReg offset1 = check_and_seek(cc, addr, offset, bytes);
-    if (!offset1)
+    JitReg memory_data, offset1;
+    if (!prepare_memory_access(cc, addr, offset, bytes, &memory_data,
+                                 &offset1))
         goto fail;
     CHECK_ALIGNMENT(offset1);
 

--- a/core/iwasm/include/aot_comp_option.h
+++ b/core/iwasm/include/aot_comp_option.h
@@ -6,6 +6,7 @@
 #ifndef __AOT_COMP_OPTION_H__
 #define __AOT_COMP_OPTION_H__
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -84,6 +85,7 @@ typedef struct AOTCompOption {
     bool quick_invoke_c_api_import;
     bool enable_shared_heap;
     bool enable_shared_chain;
+    bool enable_raw_memory;
     char *use_prof_file;
     uint32_t opt_level;
     uint32_t size_level;

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -355,6 +355,30 @@ typedef struct SharedHeapInitArgs {
 } SharedHeapInitArgs;
 
 /**
+ * Addressing mode for a module instance.
+ * Sandbox (default): guest addresses are linear-memory offsets.
+ * Raw: guest integers are host pointers (trusted / ELF-like apps).
+ * Requires WAMR_BUILD_RAW_MEMORY=1 at build time to take effect.
+ */
+typedef enum wasm_address_mode {
+    WASM_ADDR_SANDBOX = 0,
+    WASM_ADDR_RAW = 1
+} wasm_address_mode_t;
+
+/**
+ * Host heap hooks used when address mode is WASM_ADDR_RAW.
+ * If unset, the runtime uses os_malloc / os_free / os_realloc / calloc.
+ * Metal or other embedders may override. mmap stays outside WAMR.
+ */
+typedef struct WASMRawAllocHooks {
+    void *(*malloc_func)(void *env, size_t size);
+    void (*free_func)(void *env, void *ptr);
+    void *(*realloc_func)(void *env, void *ptr, size_t size);
+    void *(*calloc_func)(void *env, size_t nmemb, size_t size);
+    void *env;
+} WASMRawAllocHooks;
+
+/**
  * Initialize the WASM runtime environment, and also initialize
  * the memory allocator with system allocator, which calls os_malloc
  * to allocate memory
@@ -1411,6 +1435,33 @@ WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_is_bounds_checks_enabled(wasm_module_inst_t module_inst);
 
 /**
+ * Set the addressing mode of a module instance.
+ * Must be called before the instance runs (and before Fast-JIT compiles).
+ * WASM_ADDR_RAW refuses SharedHeap and forces bounds checks off.
+ * Requires WAMR_BUILD_RAW_MEMORY=1; otherwise returns false.
+ *
+ * @return true on success, false on failure
+ */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_set_address_mode(wasm_module_inst_t module_inst,
+                              wasm_address_mode_t mode);
+
+/**
+ * Get the addressing mode of a module instance.
+ */
+WASM_RUNTIME_API_EXTERN wasm_address_mode_t
+wasm_runtime_get_address_mode(wasm_module_inst_t module_inst);
+
+/**
+ * Install raw alloc hooks for a Raw-mode instance (optional).
+ * Pass NULL to restore default os_* / calloc hooks.
+ * Requires WAMR_BUILD_RAW_MEMORY=1; otherwise returns false.
+ */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_set_raw_alloc_hooks(wasm_module_inst_t module_inst,
+                                 const WASMRawAllocHooks *hooks);
+
+/**
  * Allocate memory from the heap of WASM module instance
  *
  * Note: wasm_runtime_module_malloc can call heap functions inside
@@ -1432,6 +1483,23 @@ wasm_runtime_is_bounds_checks_enabled(wasm_module_inst_t module_inst);
 WASM_RUNTIME_API_EXTERN uint64_t
 wasm_runtime_module_malloc(wasm_module_inst_t module_inst, uint64_t size,
                            void **p_native_addr);
+
+/**
+ * Reallocate memory from the heap of WASM module instance
+ *
+ * In WASM_ADDR_RAW mode the returned value is the host pointer bits
+ * (same as wasm_runtime_module_malloc).
+ *
+ * @param module_inst the WASM module instance which contains heap
+ * @param ptr the previous allocation (app offset or Raw host pointer)
+ * @param size the new size in bytes
+ * @param p_native_addr return native address if not NULL
+ *
+ * @return non-zero on success, zero on failure
+ */
+WASM_RUNTIME_API_EXTERN uint64_t
+wasm_runtime_module_realloc(wasm_module_inst_t module_inst, uint64_t ptr,
+                            uint64_t size, void **p_native_addr);
 
 /**
  * Free memory to the heap of WASM module instance

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -1156,6 +1156,11 @@ struct WASMModule {
     bool is_bulk_memory_used;
 #endif
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    /* Bake-in addressing mode for Fast-JIT (shared across instances). */
+    uint8 address_mode;
+#endif
+
     /* user defined name */
     char *name;
 

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -54,10 +54,11 @@ typedef float64 CellType_F64;
     do {                                                                       \
         uint64 offset1 = (uint64)offset + (uint64)addr;                        \
         CHECK_SHARED_HEAP_OVERFLOW(offset1, bytes, maddr)                      \
-        if (disable_bounds_checks || offset1 + bytes <= get_linear_mem_size()) \
+        if (WASM_BOUNDS_OK(disable_bounds_checks                               \
+                           || offset1 + bytes <= get_linear_mem_size()))       \
             /* If offset1 is in valid range, maddr must also                   \
                be in valid range, no need to check it again. */                \
-            maddr = memory->memory_data + offset1;                             \
+            WASM_RESOLVE_LINEAR_MADDR(offset1, maddr);                                \
         else                                                                   \
             goto out_of_bounds;                                                \
     } while (0)
@@ -66,10 +67,11 @@ typedef float64 CellType_F64;
     do {                                                                       \
         uint64 offset1 = (uint32)(start);                                      \
         CHECK_SHARED_HEAP_OVERFLOW(offset1, bytes, maddr)                      \
-        if (disable_bounds_checks || offset1 + bytes <= get_linear_mem_size()) \
+        if (WASM_BOUNDS_OK(disable_bounds_checks                               \
+                           || offset1 + bytes <= get_linear_mem_size()))       \
             /* App heap space is not valid space for                           \
              bulk memory operation */                                          \
-            maddr = memory->memory_data + offset1;                             \
+            WASM_RESOLVE_LINEAR_MADDR(offset1, maddr);                                \
         else                                                                   \
             goto out_of_bounds;                                                \
     } while (0)
@@ -81,14 +83,14 @@ typedef float64 CellType_F64;
     do {                                                  \
         uint64 offset1 = (uint64)offset + (uint64)addr;   \
         CHECK_SHARED_HEAP_OVERFLOW(offset1, bytes, maddr) \
-        maddr = memory->memory_data + offset1;            \
+        WASM_RESOLVE_LINEAR_MADDR(offset1, maddr);               \
     } while (0)
 
 #define CHECK_BULK_MEMORY_OVERFLOW(start, bytes, maddr)   \
     do {                                                  \
         uint64 offset1 = (uint32)(start);                 \
         CHECK_SHARED_HEAP_OVERFLOW(offset1, bytes, maddr) \
-        maddr = memory->memory_data + offset1;            \
+        WASM_RESOLVE_LINEAR_MADDR(offset1, maddr);               \
     } while (0)
 
 #endif /* end of !defined(OS_ENABLE_HW_BOUND_CHECK) || \
@@ -101,10 +103,10 @@ typedef float64 CellType_F64;
         uint64 offset1 = (uint64)offset + (uint64)addr;                     \
         CHECK_SHARED_HEAP_OVERFLOW(offset1, bytes, maddr)                   \
         /* If memory64 is enabled, offset1, offset1 + bytes can overflow */ \
-        if (disable_bounds_checks                                           \
-            || (offset1 >= offset && offset1 + bytes >= offset1             \
-                && offset1 + bytes <= get_linear_mem_size()))               \
-            maddr = memory->memory_data + offset1;                          \
+        if (WASM_BOUNDS_OK(disable_bounds_checks                            \
+                           || (offset1 >= offset && offset1 + bytes >= offset1 \
+                               && offset1 + bytes <= get_linear_mem_size()))) \
+            WASM_RESOLVE_LINEAR_MADDR(offset1, maddr);                             \
         else                                                                \
             goto out_of_bounds;                                             \
     } while (0)
@@ -114,12 +116,12 @@ typedef float64 CellType_F64;
         uint64 offset1 = (uint64)(start);                          \
         CHECK_SHARED_HEAP_OVERFLOW(offset1, bytes, maddr)          \
         /* If memory64 is enabled, offset1 + bytes can overflow */ \
-        if (disable_bounds_checks                                  \
-            || (offset1 + bytes >= offset1                         \
-                && offset1 + bytes <= get_linear_mem_size()))      \
+        if (WASM_BOUNDS_OK(disable_bounds_checks                   \
+                           || (offset1 + bytes >= offset1          \
+                               && offset1 + bytes <= get_linear_mem_size()))) \
             /* App heap space is not valid space for               \
              bulk memory operation */                              \
-            maddr = memory->memory_data + offset1;                 \
+            WASM_RESOLVE_LINEAR_MADDR(offset1, maddr);                    \
         else                                                       \
             goto out_of_bounds;                                    \
     } while (0)
@@ -1621,6 +1623,10 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #else
     bool disable_bounds_checks = false;
 #endif
+#endif
+#if WASM_ENABLE_RAW_MEMORY != 0
+    bool is_raw_address_mode =
+        wasm_runtime_is_raw_address_mode((WASMModuleInstanceCommon *)module);
 #endif
 #if WASM_ENABLE_GC != 0
     WASMObjectRef gc_obj;
@@ -4710,6 +4716,9 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 delta = POP_PAGE_COUNT();
 
                 if (
+#if WASM_ENABLE_RAW_MEMORY != 0
+                    is_raw_address_mode ||
+#endif
 #if WASM_ENABLE_MEMORY64 != 0
                     delta > UINT32_MAX ||
 #endif
@@ -5754,9 +5763,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         else
 #endif
                         {
-                            if ((uint64)(uint32)addr + bytes > linear_mem_size)
-                                goto out_of_bounds;
-                            maddr = memory->memory_data + (uint32)addr;
+                            WASM_RESOLVE_BULK_HW((uint32)addr, bytes, maddr);
                         }
 #endif
 
@@ -5820,9 +5827,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         else
 #endif
                         {
-                            if ((uint64)dst + len > linear_mem_size)
-                                goto out_of_bounds;
-                            mdst = memory->memory_data + dst;
+                            WASM_RESOLVE_BULK_HW(dst, len, mdst);
                         }
 #endif /* end of OS_ENABLE_HW_BOUND_CHECK */
 
@@ -5847,9 +5852,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         else
 #endif
                         {
-                            if ((uint64)src + len > linear_mem_size)
-                                goto out_of_bounds;
-                            msrc = memory->memory_data + src;
+                            WASM_RESOLVE_BULK_HW(src, len, msrc);
                         }
 #endif
 
@@ -5900,9 +5903,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         else
 #endif
                         {
-                            if ((uint64)(uint32)dst + len > linear_mem_size)
-                                goto out_of_bounds;
-                            mdst = memory->memory_data + (uint32)dst;
+                            WASM_RESOLVE_BULK_HW((uint32)dst, len, mdst);
                         }
 #endif
 

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -47,10 +47,11 @@ typedef float64 CellType_F64;
     do {                                                                       \
         uint64 offset1 = (uint64)offset + (uint64)addr;                        \
         CHECK_SHARED_HEAP_OVERFLOW(offset1, bytes, maddr)                      \
-        if (disable_bounds_checks || offset1 + bytes <= get_linear_mem_size()) \
+        if (WASM_BOUNDS_OK(disable_bounds_checks                               \
+                           || offset1 + bytes <= get_linear_mem_size()))       \
             /* If offset1 is in valid range, maddr must also                   \
                 be in valid range, no need to check it again. */               \
-            maddr = memory->memory_data + offset1;                             \
+            WASM_RESOLVE_LINEAR_MADDR(offset1, maddr);                                \
         else                                                                   \
             goto out_of_bounds;                                                \
     } while (0)
@@ -59,10 +60,11 @@ typedef float64 CellType_F64;
     do {                                                                       \
         uint64 offset1 = (uint32)(start);                                      \
         CHECK_SHARED_HEAP_OVERFLOW(offset1, bytes, maddr)                      \
-        if (disable_bounds_checks || offset1 + bytes <= get_linear_mem_size()) \
+        if (WASM_BOUNDS_OK(disable_bounds_checks                               \
+                           || offset1 + bytes <= get_linear_mem_size()))       \
             /* App heap space is not valid space for                           \
                bulk memory operation */                                        \
-            maddr = memory->memory_data + offset1;                             \
+            WASM_RESOLVE_LINEAR_MADDR(offset1, maddr);                                \
         else                                                                   \
             goto out_of_bounds;                                                \
     } while (0)
@@ -71,14 +73,14 @@ typedef float64 CellType_F64;
     do {                                                  \
         uint64 offset1 = (uint64)offset + (uint64)addr;   \
         CHECK_SHARED_HEAP_OVERFLOW(offset1, bytes, maddr) \
-        maddr = memory->memory_data + offset1;            \
+        WASM_RESOLVE_LINEAR_MADDR(offset1, maddr);               \
     } while (0)
 
 #define CHECK_BULK_MEMORY_OVERFLOW(start, bytes, maddr)   \
     do {                                                  \
         uint64 offset1 = (uint32)(start);                 \
         CHECK_SHARED_HEAP_OVERFLOW(offset1, bytes, maddr) \
-        maddr = memory->memory_data + offset1;            \
+        WASM_RESOLVE_LINEAR_MADDR(offset1, maddr);               \
     } while (0)
 #endif /* !defined(OS_ENABLE_HW_BOUND_CHECK) \
           || WASM_CPU_SUPPORTS_UNALIGNED_ADDR_ACCESS == 0 */
@@ -1553,6 +1555,10 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #else
     bool disable_bounds_checks = false;
 #endif
+#endif
+#if WASM_ENABLE_RAW_MEMORY != 0
+    bool is_raw_address_mode =
+        wasm_runtime_is_raw_address_mode((WASMModuleInstanceCommon *)module);
 #endif
 #if WASM_ENABLE_GC != 0
     WASMObjectRef gc_obj;
@@ -3991,7 +3997,12 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 delta = (uint32)frame_lp[addr1];
 
                 /* TODO: multi-memory wasm_enlarge_memory_with_idx() */
+#if WASM_ENABLE_RAW_MEMORY != 0
+                if (is_raw_address_mode
+                    || !wasm_enlarge_memory(module, delta)) {
+#else
                 if (!wasm_enlarge_memory(module, delta)) {
+#endif
                     /* failed to memory.grow, return -1 */
                     frame_lp[addr_ret] = -1;
                 }
@@ -5172,9 +5183,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         else
 #endif
                         {
-                            if ((uint64)(uint32)addr + bytes > linear_mem_size)
-                                goto out_of_bounds;
-                            maddr = memory->memory_data + (uint32)addr;
+                            WASM_RESOLVE_BULK_HW((uint32)addr, bytes, maddr);
                         }
 #endif
                         if (bh_bitmap_get_bit(module->e->common.data_dropped,
@@ -5229,9 +5238,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         else
 #endif
                         {
-                            if ((uint64)(uint32)src + len > linear_mem_size)
-                                goto out_of_bounds;
-                            msrc = memory->memory_data + (uint32)src;
+                            WASM_RESOLVE_BULK_HW((uint32)src, len, msrc);
                         }
 
 #if WASM_ENABLE_SHARED_HEAP != 0
@@ -5241,9 +5248,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         else
 #endif
                         {
-                            if ((uint64)(uint32)dst + len > linear_mem_size)
-                                goto out_of_bounds;
-                            mdst = memory->memory_data + (uint32)dst;
+                            WASM_RESOLVE_BULK_HW((uint32)dst, len, mdst);
                         }
 #endif /* end of OS_ENABLE_HW_BOUND_CHECK */
 
@@ -5287,9 +5292,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         else
 #endif
                         {
-                            if ((uint64)(uint32)dst + len > linear_mem_size)
-                                goto out_of_bounds;
-                            mdst = memory->memory_data + (uint32)dst;
+                            WASM_RESOLVE_BULK_HW((uint32)dst, len, mdst);
                         }
 #endif
 

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -3820,6 +3820,22 @@ wasm_module_malloc_internal(WASMModuleInstance *module_inst,
     uint8 *addr = NULL;
     uint64 offset = 0;
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(
+            (WASMModuleInstanceCommon *)module_inst)) {
+        addr = wasm_runtime_raw_malloc((WASMModuleInstanceCommon *)module_inst,
+                                      size);
+        if (!addr) {
+            LOG_WARNING("warning: allocate %" PRIu64 " bytes memory failed",
+                        size);
+            return 0;
+        }
+        if (p_native_addr)
+            *p_native_addr = addr;
+        return (uint64)(uintptr_t)addr;
+    }
+#endif
+
     /* TODO: Memory64 size check based on memory idx type */
     bh_assert(size <= UINT32_MAX);
 
@@ -3869,6 +3885,21 @@ wasm_module_realloc_internal(WASMModuleInstance *module_inst,
     WASMMemoryInstance *memory = wasm_get_default_memory(module_inst);
     uint8 *addr = NULL;
 
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(
+            (WASMModuleInstanceCommon *)module_inst)) {
+        addr = wasm_runtime_raw_realloc((WASMModuleInstanceCommon *)module_inst,
+                                       (void *)(uintptr_t)ptr, size);
+        if (!addr && size != 0) {
+            wasm_set_exception(module_inst, "out of memory");
+            return 0;
+        }
+        if (p_native_addr)
+            *p_native_addr = addr;
+        return (uint64)(uintptr_t)addr;
+    }
+#endif
+
     /* TODO: Memory64 ptr and size check based on memory idx type */
     bh_assert(ptr <= UINT32_MAX);
     bh_assert(size <= UINT32_MAX);
@@ -3909,6 +3940,15 @@ wasm_module_free_internal(WASMModuleInstance *module_inst,
                           WASMExecEnv *exec_env, uint64 ptr)
 {
     WASMMemoryInstance *memory = wasm_get_default_memory(module_inst);
+
+#if WASM_ENABLE_RAW_MEMORY != 0
+    if (wasm_runtime_is_raw_address_mode(
+            (WASMModuleInstanceCommon *)module_inst)) {
+        wasm_runtime_raw_free((WASMModuleInstanceCommon *)module_inst,
+                              (void *)(uintptr_t)ptr);
+        return;
+    }
+#endif
 
     /* TODO: Memory64 ptr and size check based on memory idx type */
     bh_assert(ptr <= UINT32_MAX);

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -321,6 +321,11 @@ typedef struct WASMModuleInstanceExtraCommon {
     /* Disable bounds checks or not */
     bool disable_bounds_checks;
 #endif
+#if WASM_ENABLE_RAW_MEMORY != 0
+    /* WASM_ADDR_SANDBOX (0) or WASM_ADDR_RAW (1) */
+    uint8 address_mode;
+    WASMRawAllocHooks raw_alloc_hooks;
+#endif
 #if WASM_ENABLE_BULK_MEMORY != 0
     bh_bitmap *data_dropped;
 #endif

--- a/doc/raw_memory.md
+++ b/doc/raw_memory.md
@@ -1,0 +1,140 @@
+# Raw address mode
+
+Raw mode turns off linear-memory isolation for an instance: guest integers
+are **host pointers**, and wasm becomes a **code container** in one process
+VA. Call into host / sibling modules with real pointers; load and store as
+if everything were local. That is the point. Any speedup is a side effect
+of not paying sandbox taxes.
+
+Opt-in at build time and per instance. Default WAMR builds stay
+sandbox-only.
+
+## Build
+
+```bash
+cmake ... -DWAMR_BUILD_RAW_MEMORY=1
+```
+
+Default is `0`: no Raw specialization on hot paths.
+
+Forbidden with `WAMR_BUILD_SHARED_HEAP=1`. Works on 32- and 64-bit hosts.
+
+## Modes
+
+| Mode | Guest address | Load / store | `module_malloc` |
+|------|---------------|--------------|-----------------|
+| `WASM_ADDR_SANDBOX` (default) | mem32 `i32` / mem64 `i64` offset | `base + offset` | linear / app heap offset |
+| `WASM_ADDR_RAW` | host `uintptr_t` bits | dereference as-is | host heap hooks → real pointer |
+
+Raw is a **platform ABI**, not a wasm `memtype`.
+
+## Embedder API
+
+```c
+wasm_runtime_set_address_mode(inst, WASM_ADDR_RAW);
+wasm_runtime_set_raw_alloc_hooks(inst, &hooks); /* optional */
+```
+
+Call **before** the instance runs (and before Fast-JIT compiles). Setting
+Raw turns bounds checks off for that instance.
+
+### Alloc hooks
+
+```c
+typedef struct WASMRawAllocHooks {
+    void *(*malloc_func)(void *env, size_t size);
+    void (*free_func)(void *env, void *ptr);
+    void *(*realloc_func)(void *env, void *ptr, size_t size);
+    void *(*calloc_func)(void *env, size_t nmemb, size_t size);
+    void *env;
+} WASMRawAllocHooks;
+```
+
+Unset hooks → `os_malloc` / `os_free` / `os_realloc` / zero-filled
+`os_malloc`. Metal may replace them. WAMR does not expose mmap; the
+allocator owner can use mmap internally.
+
+`memory.grow` returns `-1` in Raw mode.
+
+## Nested loaders (sandbox outer, Raw inner)
+
+Address mode is **per instance**. There is no nested subdivision of
+address spaces.
+
+Example: sandboxed outer (e.g. MicroPython-as-wasm) with a host/native
+loader that instantiates an inner module.
+
+| Outer | Inner | What the inner “sees” |
+|-------|-------|------------------------|
+| Sandbox | Sandbox | Its **own** private linear memory. Outer’s buffer is invisible unless you copy, Shared Heap, or pass converted host pointers through imports. |
+| Sandbox | **Raw** | The **process VA** (or whatever host pointers the loader / hooks hand it). **Not** “outer’s linear memory, remapped as the whole world.” Outer’s sandbox is just one host buffer among many. |
+| Raw | Raw | One shared VA. Pointers are local; call and access like siblings in one app. |
+
+So: putting Raw under an isolated outer does **not** confine Raw to the
+outer’s mem. Outer isolation does not wrap the inner. If the loader only
+ever passes pointers into outer’s `memory_data`, Raw *can* poke that blob
+as plain host memory — but Raw can also `malloc` process heap, forge
+pointers, or touch anything else in the process. Treat Raw inners as
+**process-trusted**, even when the parent module is sandboxed.
+
+**Alloc chain is embedder policy.** WAMR does not forward child allocs to
+a parent. A loader may set `wasm_runtime_set_raw_alloc_hooks` so each
+level’s `module_malloc` calls the parent’s (sandbox linear or Raw/os).
+Demo: unit test `nest_alloc_chain_sandbox_vs_raw_outer` (outermost Raw
+vs outermost sandbox vs unhooked escape).
+
+## Engines
+
+| Engine | Specialization |
+|--------|----------------|
+| Classic / fast interp | Mode read once at call entry; resolve absolute `maddr` |
+| Fast-JIT | Mode baked from `module->address_mode` at compile time |
+| AOT | Compile with `wamrc --enable-raw-memory`; set instance to Raw |
+
+## Address width
+
+Raw does not invent a new pointer size: the guest type still comes from
+the module’s memory (`i32` for mem32, `i64` for mem64). So:
+
+- **mem32** — guest addresses are 32-bit. On a 32-bit host that matches
+  `uintptr_t`. On a 64-bit host the pointer value must still fit in
+  `i32` (typical: allocate in the low 4 GiB, e.g. `MAP_32BIT`).
+- **mem64** — guest addresses are 64-bit; full host pointers on a 64-bit
+  host. Use classic/fast interp or AOT (`wamrc --enable-raw-memory`).
+  Fast-JIT does not support Memory64 (upstream WAMR limit, unrelated to
+  Raw).
+
+## Testing
+
+```bash
+# Default profile: classic interp + Fast-JIT (+ AOT fixture via wamrc)
+cmake -S tests/unit/raw-memory -B build-raw -DRAW_MEMORY_TEST_PROFILE=fast_jit
+cmake --build build-raw && (cd build-raw && ./raw_memory_test)
+
+# All engine profiles (fast_jit, fast_interp, memory64)
+tests/unit/raw-memory/run_matrix.sh
+```
+
+Profiles cover bulk `memory.fill` / `memory.copy`, `memory.grow` → `-1`,
+default `os_*` hooks, public `wasm_runtime_module_realloc`, and AOT
+(`wamrc --enable-raw-memory`) when LLVM is available.
+
+### Microbench (sandbox vs Raw)
+
+Optional. Useful to show where sandbox taxes show up; not the product
+pitch.
+
+```bash
+cmake -S tests/unit/raw-memory -B build-bench -DCMAKE_BUILD_TYPE=Release \
+  -DRAW_MEMORY_TEST_PROFILE=fast_jit
+cmake --build build-bench --target raw_memory_bench
+(cd build-bench && ./raw_memory_bench 300)
+```
+
+Workloads: in-wasm `sum_i32` / `touch_i32`, `host_churn` (wasm→host `*`
+arg), and `shared_pool` (two instances, pointer share vs memcpy).
+
+## Trust model
+
+Raw has **no** linear-memory isolation. Only load trusted modules compiled
+for host pointers. A sandboxed parent does **not** contain a Raw child.

--- a/doc/raw_memory_PR_NOTE.md
+++ b/doc/raw_memory_PR_NOTE.md
@@ -1,0 +1,166 @@
+# PR: Raw address mode (`WAMR_BUILD_RAW_MEMORY`)
+
+## Sorry / not sorry
+
+We're sorry for poking a hole in WAMR's beloved linear-memory isolation.
+
+We're not sorry about what that hole makes possible when you **intentionally**
+opt in: wasm as a **code container** where you call everything as local and
+access everything as local — closely tied pieces in one VA — instead of a
+nest of sandboxed tenants that each own (and often waste) their own address
+space. Speedups are a nice side effect of dropping that theater.
+
+Default builds are unchanged. Sandbox stays the default. Raw is build-gated,
+per-instance, and documented as trusted-only.
+
+Mutually exclusive with Shared Heap — not because we couldn't wire both, but
+because it barely makes sense: Shared Heap exists to punch a shared window
+*through* sandbox isolation. In Raw, guest ints are already host pointers in
+one VA; the whole heap is shared. Stacking both is “shared, but also shared.”
+
+## Why (the product)
+
+Sandbox isolation is the right default for untrusted modules. For products
+that already trust their wasm (same process, same team, same ship), the
+pain is **architectural**, not “we need 2× fewer nanoseconds”:
+
+- **Call everything as local** — guest `*` / `$` args *are* host pointers;
+  host and sibling modules talk without offset↔native theater.
+- **Access everything as local** — one process VA; allocators / arenas /
+  shared buffers live where C would put them.
+- **Code container, not tenant farm** — modules are compilation units /
+  plugins inside one app. No private linear memory per sibling “just
+  because wasm.”
+
+Portable IR + load/JIT/AOT, without pretending siblings need mem fences.
+
+## One VA, optional alloc chain
+
+Address mode is **per instance**. There is only one real address space: the
+**process VA**. Nested Raw does not invent nested VAs.
+
+Raw sees host pointers. A sandboxed outer that loads a Raw inner does **not**
+give the inner “outer’s linear memory as its universe,” and outer isolation
+does **not** wrap Raw. Default Raw `module_malloc` is `os_*` (process heap)
+unless the embedder says otherwise.
+
+**Alloc hooks are embedder policy**, not automatic hierarchy. The loader
+decides what the guest’s heap *is*:
+
+- **Host / base alloc** — default `os_*` or your process allocator (full
+  VA; Linux-process shape).
+- **Parent borders** — forward into a sandboxed outer’s
+  `module_malloc` / linear mem (cooperative “live in my blob”).
+- **Separate arena** — hooks that only hand out pointers from some other
+  region (mmap slab, pool, Metal arena, …) that lives wherever you put it.
+
+```
+process VA
+├── A  outermost Raw  (Linux-process shape)
+│     top(raw) ──os_*/mmap──► host heap          ← owns the pool
+│       └── mid(raw)  hooks → top
+│             └── leaf(raw)  hooks → mid
+│                   malloc walks leaf → mid → top
+│
+├── B  outermost Sandbox  (cooperative “live in my blob”)
+│     outer(sandbox) ──► outer linear memory     ← owns the pool
+│       └── mid(raw)  hooks → outer.module_malloc
+│             └── leaf(raw)  hooks → mid
+│                   bytes land inside outer’s borders
+│
+├── C  separate arena  (loader-drawn box anywhere in VA)
+│     arena / mmap slab                          ← owns the pool
+│       └── child(raw)  hooks → arena only
+│
+└── ✗  Raw under sandbox, NO hooks
+      outer(sandbox)  linear mem
+      inner(raw) ──os_*──► process heap          ← escapes outer
+```
+
+A loader may chain levels (`leaf → mid → top`) so whoever actually backs
+memory owns the pool and everyone below shares that VA. If the **top** is
+Raw with `os_*` / mmap, the stack behaves like a normal Linux process —
+wasm is just more code in one address space.
+
+Hooking only steers **cooperative** heap traffic. It is not a security
+boundary: forge a pointer and you are still on process VA.
+
+Demo (prints the chain): unit test
+`nest_alloc_chain_sandbox_vs_raw_outer` — outermost Raw vs outermost
+sandbox vs unhooked escape. Details: [`doc/raw_memory.md`](raw_memory.md)
+§ Nested loaders.
+
+## Nice side effect: measured speedups
+
+Speed is what you get when you stop paying taxes you did not want — not
+the reason to ship Raw. Microbench
+`tests/unit/raw-memory/raw_memory_bench` (Release, x86_64, 16 384 elems ×
+300 rounds, order-swapped medians of 5).
+
+| Engine | Config | Workload | Sandbox | Raw | Speedup |
+|--------|--------|----------|---------|-----|---------|
+| Fast-JIT | HW bounds | `host_churn` (wasm→host `*` arg) | 11.8 ns/el | 4.3 ns/el | **~2.7×** |
+| Fast-JIT | soft bounds | `host_churn` | 11.5 ns/el | 4.4 ns/el | **~2.6×** |
+| AOT | soft (`wamrc` ± `--enable-raw-memory`) | `host_churn` | 0.294 s | 0.214 s | **~1.4×** |
+| Fast-interp | soft bounds | `host_churn` | 83.3 ns/el | 68.6 ns/el | ~1.2× |
+| Fast-JIT | HW / soft | in-wasm `sum_i32` / `touch_i32` | ~2.5–3.2 ns/el | ~2.5–3.0 ns/el | ~1.0–1.09× |
+| Fast-JIT | soft | `shared_pool` (2 mods, write+share+read) | 0.015 s | 0.014 s | ~1.1× |
+
+Reading the table honestly:
+
+- **Host pointer calls** (Fast-JIT) show the convert tax clearly once the
+  rest of the path is already lean.
+- **Fast-interp ~1.2×** is small because the baseline is fat: dispatch
+  dominates, so removing convert is a modest fraction of a slow path
+  (same absolute save looks bigger under Fast-JIT).
+- **In-wasm loads under HW bounds** ≈ parity — isolation was already
+  cheap there.
+- **`shared_pool`** wall time on a tiny buffer is still the write/read
+  loops; the real win is no private linear mem / no copy architecture.
+
+```bash
+cmake -S tests/unit/raw-memory -B build-bench -DCMAKE_BUILD_TYPE=Release \
+  -DRAW_MEMORY_TEST_PROFILE=fast_jit
+cmake --build build-bench --target raw_memory_bench
+(cd build-bench && ./raw_memory_bench 300)
+```
+
+## What
+
+| Piece | Behavior |
+|-------|----------|
+| Build | `-DWAMR_BUILD_RAW_MEMORY=1` (default `0`) |
+| API | `wasm_runtime_set_address_mode(inst, WASM_ADDR_RAW)` + optional alloc hooks |
+| Engines | Classic / fast interp, Fast-JIT (mode baked at compile), AOT via `wamrc --enable-raw-memory` |
+| `memory.grow` | returns `-1` in Raw |
+| Shared Heap | cmake-refused with Raw (redundant once the whole VA is shared) |
+| Hosts | 32- and 64-bit (mem32 on 64-bit still needs pointers that fit in `i32`) |
+
+Details: [`doc/raw_memory.md`](raw_memory.md).
+
+## Trust model
+
+Raw has **no** linear-memory isolation. One bad store can trash the process.
+Only load modules compiled/understood for host pointers. A sandboxed parent
+does **not** contain a Raw child. If you need tenants, keep sandbox (on
+every instance that must stay a tenant).
+
+## Test plan
+
+```bash
+# refuse
+cmake ... -DWAMR_BUILD_RAW_MEMORY=1 -DWAMR_BUILD_SHARED_HEAP=1   # must FATAL
+
+# product-mini
+cmake ... -DWAMR_BUILD_RAW_MEMORY=0   # build
+cmake ... -DWAMR_BUILD_RAW_MEMORY=1   # build (x86_64 and X86_32)
+
+# unit matrix
+tests/unit/raw-memory/run_matrix.sh
+# incl. nest_alloc_chain_sandbox_vs_raw_outer (hook chain demo)
+# fast_jit / fast_interp / memory64 — load/store, bulk, grow→-1, hooks, AOT
+```
+
+Verified locally before this PR: refuse Shared+Raw; PM RAW=0/1 + Fast-JIT
++ X86_32; matrix **13+8+11**; nest A/B/escape; Fast-JIT sandbox/raw smoke
+×80; rebench soft/HW Fast-JIT + AOT + fast-interp (numbers above).

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -69,6 +69,11 @@ if (NOT DEFINED WAMR_BUILD_FAST_JIT)
   set (WAMR_BUILD_FAST_JIT 0)
 endif ()
 
+if (NOT DEFINED WAMR_BUILD_RAW_MEMORY)
+  # Disable raw (host-pointer) address mode by default
+  set (WAMR_BUILD_RAW_MEMORY 0)
+endif ()
+
 if (NOT DEFINED WAMR_BUILD_LIBC_BUILTIN)
   # Enable libc builtin support by default
   set (WAMR_BUILD_LIBC_BUILTIN 1)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -123,6 +123,7 @@ if(WAMR_BUILD_TARGET STREQUAL "X86_64")
 
   add_subdirectory (memory64)
   add_subdirectory (shared-heap)
+  add_subdirectory (raw-memory)
 
   # HW_BOUND_CHECK is not supported on X86_32
   add_subdirectory (runtime-common)
@@ -137,6 +138,7 @@ if(WAMR_BUILD_TARGET STREQUAL "AARCH64")
 
   add_subdirectory (memory64)
   add_subdirectory (shared-heap)
+  add_subdirectory (raw-memory)
 
   add_subdirectory (runtime-common)
 endif ()

--- a/tests/unit/raw-memory/.gitignore
+++ b/tests/unit/raw-memory/.gitignore
@@ -1,0 +1,3 @@
+# Generated test fixtures (built by CMake / gen_raw_mem_test_wasm.py)
+*.wasm
+*.aot

--- a/tests/unit/raw-memory/CMakeLists.txt
+++ b/tests/unit/raw-memory/CMakeLists.txt
@@ -1,0 +1,221 @@
+# Copyright (C) 2026 Pymergetic | Rouven Raudzus. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.14)
+
+project(test-raw-memory)
+
+add_definitions(-DRUN_ON_LINUX)
+
+# Engine profile (override from CLI / matrix script):
+#   fast_jit     — classic interp + Fast-JIT (default)
+#   fast_interp  — fast interpreter only
+#   memory64     — classic interp + Memory64 (no Fast-JIT)
+set(RAW_MEMORY_TEST_PROFILE "fast_jit" CACHE STRING
+    "Raw unit-test engine profile: fast_jit|fast_interp|memory64")
+
+set(WAMR_BUILD_APP_FRAMEWORK 0)
+set(WAMR_BUILD_JIT 0)
+set(WAMR_BUILD_SHARED_HEAP 0)
+set(WAMR_BUILD_RAW_MEMORY 1)
+set(WAMR_BUILD_LIBC_WASI 0)
+set(WAMR_BUILD_WAMR_COMPILER 0)
+set(WAMR_BUILD_INTERP 1)
+set(WAMR_BUILD_BULK_MEMORY 1)
+set(WAMR_BUILD_BULK_MEMORY_OPT 1)
+
+if (RAW_MEMORY_TEST_PROFILE STREQUAL "fast_interp")
+  set(WAMR_BUILD_AOT 0)
+  set(WAMR_BUILD_FAST_JIT 0)
+  set(WAMR_BUILD_FAST_INTERP 1)
+  set(WAMR_BUILD_MEMORY64 0)
+elseif (RAW_MEMORY_TEST_PROFILE STREQUAL "memory64")
+  set(WAMR_BUILD_AOT 1)
+  set(WAMR_BUILD_FAST_JIT 0)
+  set(WAMR_BUILD_FAST_INTERP 0)
+  set(WAMR_BUILD_MEMORY64 1)
+else ()
+  # fast_jit (default)
+  set(WAMR_BUILD_AOT 1)
+  set(WAMR_BUILD_FAST_JIT 1)
+  set(WAMR_BUILD_FAST_INTERP 1) # forced off by Fast-JIT in config_common
+  set(WAMR_BUILD_MEMORY64 0)
+endif ()
+
+message(STATUS "Raw memory unit-test profile: ${RAW_MEMORY_TEST_PROFILE}")
+
+# Standalone builds need gtest; when included from tests/unit parent it
+# is already available.
+if (NOT TARGET gtest_main)
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+  )
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+  include(GoogleTest)
+  enable_testing()
+endif ()
+
+# unit_common.cmake insists on an LLVM_DIR; point at system LLVM when the
+# WAMR-bundled tree is absent (standalone Fast-JIT/interp harness).
+if (NOT DEFINED LLVM_DIR AND NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../core/deps/llvm/build")
+  if (EXISTS /usr/lib/llvm-18/lib/cmake/llvm)
+    set(LLVM_DIR /usr/lib/llvm-18/lib/cmake/llvm)
+  endif ()
+endif ()
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../unit_common.cmake)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+file(GLOB_RECURSE source_all ${CMAKE_CURRENT_SOURCE_DIR}/*.cc)
+list(FILTER source_all EXCLUDE REGEX "raw_memory_bench\\.cc$")
+set(UNIT_SOURCE ${source_all})
+
+set(unit_test_sources
+  ${UNIT_SOURCE}
+  ${WAMR_RUNTIME_LIB_SOURCE}
+  ${UNCOMMON_SHARED_SOURCE}
+)
+
+add_executable(raw_memory_test ${unit_test_sources})
+target_link_libraries(raw_memory_test gtest_main)
+
+add_executable(raw_memory_bench
+  ${CMAKE_CURRENT_SOURCE_DIR}/raw_memory_bench.cc
+  ${WAMR_RUNTIME_LIB_SOURCE}
+  ${UNCOMMON_SHARED_SOURCE}
+)
+target_link_libraries(raw_memory_bench pthread m dl)
+
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+set(RAW_MEM_TEST_WASM ${CMAKE_CURRENT_BINARY_DIR}/raw_mem_test.wasm)
+set(RAW_MEM_BENCH_WASM ${CMAKE_CURRENT_BINARY_DIR}/raw_mem_bench.wasm)
+add_custom_command(
+  OUTPUT ${RAW_MEM_TEST_WASM}
+  COMMAND ${Python3_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/wasm-apps/gen_raw_mem_test_wasm.py
+          ${RAW_MEM_TEST_WASM}
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/wasm-apps/gen_raw_mem_test_wasm.py
+  COMMENT "Generate raw_mem_test.wasm fixture"
+)
+add_custom_command(
+  OUTPUT ${RAW_MEM_BENCH_WASM}
+  COMMAND ${Python3_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/wasm-apps/gen_raw_mem_bench_wasm.py
+          ${RAW_MEM_BENCH_WASM}
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/wasm-apps/gen_raw_mem_bench_wasm.py
+  COMMENT "Generate raw_mem_bench.wasm fixture"
+)
+add_custom_target(raw_mem_test_wasm DEPENDS ${RAW_MEM_TEST_WASM})
+add_custom_target(raw_mem_bench_wasm DEPENDS ${RAW_MEM_BENCH_WASM})
+add_dependencies(raw_memory_test raw_mem_test_wasm)
+add_dependencies(raw_memory_bench raw_mem_bench_wasm)
+
+if (WAMR_BUILD_MEMORY64 EQUAL 1)
+  set(RAW_MEM64_TEST_WASM ${CMAKE_CURRENT_BINARY_DIR}/raw_mem64_test.wasm)
+  add_custom_command(
+    OUTPUT ${RAW_MEM64_TEST_WASM}
+    COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/wasm-apps/gen_raw_mem_test_wasm.py
+            ${RAW_MEM64_TEST_WASM}
+            --mem64
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/wasm-apps/gen_raw_mem_test_wasm.py
+    COMMENT "Generate raw_mem64_test.wasm fixture"
+  )
+  add_custom_target(raw_mem64_test_wasm DEPENDS ${RAW_MEM64_TEST_WASM})
+  add_dependencies(raw_memory_test raw_mem64_test_wasm)
+endif ()
+
+# Optional AOT fixture via wamrc --enable-raw-memory (fast_jit / memory64 profiles).
+option(RAW_MEMORY_TEST_BUILD_AOT "Build wamrc and compile Raw AOT fixture" ON)
+if (RAW_MEMORY_TEST_BUILD_AOT AND WAMR_BUILD_AOT EQUAL 1)
+  set(WAMRC_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/wamrc-build)
+  set(WAMRC_BIN ${WAMRC_BUILD_DIR}/wamrc)
+  set(RAW_MEM_TEST_AOT ${CMAKE_CURRENT_BINARY_DIR}/raw_mem_test.aot)
+
+  # Single producer for nested wamrc — both AOT fixtures must share it so
+  # parallel make does not double-configure the same build tree.
+  add_custom_command(
+    OUTPUT ${WAMRC_BIN}
+    COMMAND ${CMAKE_COMMAND}
+            -S ${CMAKE_CURRENT_SOURCE_DIR}/../../../wamr-compiler
+            -B ${WAMRC_BUILD_DIR}
+            -DCMAKE_BUILD_TYPE=Release
+            -DWAMR_BUILD_PLATFORM=linux
+            -DWAMR_BUILD_WITH_CUSTOM_LLVM=1
+            -DLLVM_DIR=${LLVM_DIR}
+    # Nested archive builds race under high -j (ranlib/libvmlib.a); keep serial.
+    COMMAND ${CMAKE_COMMAND} --build ${WAMRC_BUILD_DIR} --target wamrc -j1
+    COMMENT "Build wamrc with Raw memory support"
+  )
+  add_custom_target(raw_memory_wamrc DEPENDS ${WAMRC_BIN})
+
+  add_custom_command(
+    OUTPUT ${RAW_MEM_TEST_AOT}
+    COMMAND ${WAMRC_BIN} --enable-raw-memory
+            -o ${RAW_MEM_TEST_AOT}
+            ${RAW_MEM_TEST_WASM}
+    DEPENDS ${RAW_MEM_TEST_WASM}
+    COMMENT "AOT-compile raw_mem_test.wasm with --enable-raw-memory"
+  )
+  add_custom_target(raw_mem_test_aot DEPENDS ${RAW_MEM_TEST_AOT})
+  add_dependencies(raw_mem_test_aot raw_memory_wamrc)
+  add_dependencies(raw_memory_test raw_mem_test_aot)
+  target_compile_definitions(raw_memory_test PRIVATE RAW_MEMORY_HAS_AOT_FIXTURE=1)
+
+  # Bench AOT fixtures: Raw-specialized vs sandbox codegen for host_churn.
+  set(RAW_MEM_BENCH_AOT_RAW ${CMAKE_CURRENT_BINARY_DIR}/raw_mem_bench_raw.aot)
+  set(RAW_MEM_BENCH_AOT_SBX ${CMAKE_CURRENT_BINARY_DIR}/raw_mem_bench_sandbox.aot)
+  add_custom_command(
+    OUTPUT ${RAW_MEM_BENCH_AOT_RAW}
+    COMMAND ${WAMRC_BIN} --enable-raw-memory
+            -o ${RAW_MEM_BENCH_AOT_RAW}
+            ${RAW_MEM_BENCH_WASM}
+    DEPENDS ${RAW_MEM_BENCH_WASM}
+    COMMENT "AOT-compile bench wasm with --enable-raw-memory"
+  )
+  add_custom_command(
+    OUTPUT ${RAW_MEM_BENCH_AOT_SBX}
+    COMMAND ${WAMRC_BIN}
+            -o ${RAW_MEM_BENCH_AOT_SBX}
+            ${RAW_MEM_BENCH_WASM}
+    DEPENDS ${RAW_MEM_BENCH_WASM}
+    COMMENT "AOT-compile bench wasm (sandbox)"
+  )
+  add_custom_target(raw_mem_bench_aot
+    DEPENDS ${RAW_MEM_BENCH_AOT_RAW} ${RAW_MEM_BENCH_AOT_SBX})
+  add_dependencies(raw_mem_bench_aot raw_memory_wamrc)
+  add_dependencies(raw_memory_bench raw_mem_bench_aot)
+  target_compile_definitions(raw_memory_bench PRIVATE RAW_MEMORY_HAS_AOT_FIXTURE=1)
+
+  if (WAMR_BUILD_MEMORY64 EQUAL 1)
+    set(RAW_MEM64_TEST_AOT ${CMAKE_CURRENT_BINARY_DIR}/raw_mem64_test.aot)
+    add_custom_command(
+      OUTPUT ${RAW_MEM64_TEST_AOT}
+      COMMAND ${WAMRC_BIN} --enable-raw-memory
+              -o ${RAW_MEM64_TEST_AOT}
+              ${RAW_MEM64_TEST_WASM}
+      DEPENDS ${RAW_MEM64_TEST_WASM}
+      COMMENT "AOT-compile raw_mem64_test.wasm with --enable-raw-memory"
+    )
+    add_custom_target(raw_mem64_test_aot DEPENDS ${RAW_MEM64_TEST_AOT})
+    add_dependencies(raw_mem64_test_aot raw_memory_wamrc)
+    add_dependencies(raw_memory_test raw_mem64_test_aot)
+    target_compile_definitions(raw_memory_test PRIVATE RAW_MEMORY_HAS_AOT64_FIXTURE=1)
+  endif ()
+endif ()
+
+gtest_discover_tests(raw_memory_test)
+
+# Convenience: build+run all engine profiles from a configured tree.
+add_custom_target(raw_memory_test_matrix
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/run_matrix.sh
+          ${CMAKE_CURRENT_SOURCE_DIR}
+          ${CMAKE_CURRENT_BINARY_DIR}/_matrix
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  USES_TERMINAL
+  COMMENT "Build and run Raw memory tests for fast_jit, fast_interp, memory64"
+)

--- a/tests/unit/raw-memory/raw_memory_bench.cc
+++ b/tests/unit/raw-memory/raw_memory_bench.cc
@@ -1,0 +1,448 @@
+/*
+ * Copyright (C) 2026 Pymergetic | Rouven Raudzus. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Microbench: sandbox vs Raw (order-swapped medians) + shared-pool productish.
+ * Usage: ./raw_memory_bench [rounds]
+ */
+
+#include "bh_read_file.h"
+#include "wasm_export.h"
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <sys/mman.h>
+#include <time.h>
+#include <vector>
+
+static constexpr uint32_t kElems = 16384;
+static constexpr size_t kBufBytes = kElems * sizeof(uint32_t);
+static constexpr int kWarmup = 3;
+static constexpr int kSamples = 5;
+
+static double
+now_sec()
+{
+    timespec ts{};
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+static int
+host_ldadd(wasm_exec_env_t exec_env, uint32_t *p)
+{
+    (void)exec_env;
+    return (int)(*p + 1u);
+}
+
+static NativeSymbol g_natives[] = {
+    { "host_ldadd", (void *)host_ldadd, "(*)i", nullptr },
+};
+
+static void *
+map32_malloc(void *env, size_t size)
+{
+    (void)env;
+    size_t map_sz = size < kBufBytes ? kBufBytes : size;
+    void *p = mmap(nullptr, map_sz, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0);
+    return p == MAP_FAILED ? nullptr : p;
+}
+
+static void
+map32_free(void *env, void *ptr)
+{
+    (void)env;
+    if (ptr)
+        munmap(ptr, kBufBytes);
+}
+
+static void *
+map32_realloc(void *env, void *ptr, size_t size)
+{
+    void *n = map32_malloc(env, size);
+    if (n && ptr) {
+        memcpy(n, ptr, size < kBufBytes ? size : kBufBytes);
+        map32_free(env, ptr);
+    }
+    return n;
+}
+
+static void *
+map32_calloc(void *env, size_t nmemb, size_t size)
+{
+    size_t total = nmemb * size;
+    void *p = map32_malloc(env, total);
+    if (p)
+        memset(p, 0, total);
+    return p;
+}
+
+struct Env {
+    wasm_module_t module = nullptr;
+    wasm_module_inst_t inst = nullptr;
+    wasm_exec_env_t exec = nullptr;
+    unsigned char *buf = nullptr;
+    void *raw_native = nullptr;
+    uint64_t raw_ptr = 0;
+};
+
+static void
+destroy(Env &e)
+{
+    if (e.exec)
+        wasm_runtime_destroy_exec_env(e.exec);
+    if (e.inst) {
+        if (e.raw_ptr)
+            wasm_runtime_module_free(e.inst, e.raw_ptr);
+        wasm_runtime_deinstantiate(e.inst);
+    }
+    if (e.module)
+        wasm_runtime_unload(e.module);
+    if (e.buf)
+        wasm_runtime_free(e.buf);
+    e = Env{};
+}
+
+static bool
+setup(Env &e, bool raw, RunningMode mode, bool malloc_raw_buf = true)
+{
+    char err[128] = {};
+    unsigned size = 0;
+    e.buf = (unsigned char *)bh_read_file_to_buffer("raw_mem_bench.wasm", &size);
+    if (!e.buf)
+        return false;
+    e.module = wasm_runtime_load(e.buf, size, err, sizeof(err));
+    if (!e.module) {
+        printf("load failed: %s\n", err);
+        return false;
+    }
+    e.inst = wasm_runtime_instantiate(e.module, 256 * 1024, 256 * 1024, err,
+                                      sizeof(err));
+    if (!e.inst) {
+        printf("instantiate failed: %s\n", err);
+        return false;
+    }
+    if (raw) {
+        if (!wasm_runtime_set_address_mode(e.inst, WASM_ADDR_RAW))
+            return false;
+        WASMRawAllocHooks hooks = { map32_malloc, map32_free, map32_realloc,
+                                    map32_calloc, nullptr };
+        if (!wasm_runtime_set_raw_alloc_hooks(e.inst, &hooks))
+            return false;
+        if (malloc_raw_buf) {
+            e.raw_ptr = wasm_runtime_module_malloc(e.inst, kBufBytes,
+                                                   &e.raw_native);
+            if (!e.raw_ptr || !e.raw_native)
+                return false;
+            for (uint32_t i = 0; i < kElems; i++)
+                ((uint32_t *)e.raw_native)[i] = i;
+        }
+    }
+    else {
+        void *mem = wasm_runtime_addr_app_to_native(e.inst, 0);
+        if (!mem)
+            return false;
+        for (uint32_t i = 0; i < kElems; i++)
+            ((uint32_t *)mem)[i] = i;
+    }
+#if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0
+    if (!wasm_runtime_set_running_mode(e.inst, mode))
+        return false;
+#else
+    (void)mode;
+#endif
+    e.exec = wasm_runtime_create_exec_env(e.inst, 64 * 1024);
+    return e.exec != nullptr;
+}
+
+static bool
+run_named(Env &e, const char *fn, uint32_t base, uint32_t n, uint32_t *out)
+{
+    wasm_function_inst_t f = wasm_runtime_lookup_function(e.inst, fn);
+    if (!f)
+        return false;
+    uint32_t argv[2] = { base, n };
+    if (!wasm_runtime_call_wasm(e.exec, f, 2, argv)) {
+        printf("call %s failed: %s\n", fn,
+               wasm_runtime_get_exception(e.inst)
+                   ? wasm_runtime_get_exception(e.inst)
+                   : "?");
+        return false;
+    }
+    *out = argv[0];
+    return true;
+}
+
+static double
+time_fn_once(Env &e, const char *fn, uint32_t base, int rounds)
+{
+    uint32_t sink = 0;
+    for (int i = 0; i < kWarmup; i++)
+        run_named(e, fn, base, kElems, &sink);
+    double t0 = now_sec();
+    for (int i = 0; i < rounds; i++)
+        run_named(e, fn, base, kElems, &sink);
+    return now_sec() - t0;
+}
+
+static double
+median(std::vector<double> v)
+{
+    std::sort(v.begin(), v.end());
+    return v[v.size() / 2];
+}
+
+static const char *
+mode_name(RunningMode m)
+{
+    switch (m) {
+        case Mode_Interp:
+            return "interp";
+#if WASM_ENABLE_FAST_JIT != 0
+        case Mode_Fast_JIT:
+            return "fast_jit";
+#endif
+        default:
+            return "other";
+    }
+}
+
+static void
+bench_pair(RunningMode mode, int rounds)
+{
+    printf("\n== engine=%s  elems=%u  rounds=%d  samples=%d (order-swapped) ==\n",
+           mode_name(mode), kElems, rounds, kSamples);
+
+    const char *fns[] = { "sum_i32", "touch_i32", "host_churn" };
+    for (const char *fn : fns) {
+        std::vector<double> sand_s, raw_s;
+        for (int s = 0; s < kSamples; s++) {
+            Env a{}, b{};
+            /* Alternate which mode runs first to cancel turbo/order bias. */
+            bool raw_first = (s & 1) != 0;
+            if (!setup(a, raw_first, mode) || !setup(b, !raw_first, mode)) {
+                printf("setup failed\n");
+                destroy(a);
+                destroy(b);
+                return;
+            }
+            Env &raw = raw_first ? a : b;
+            Env &sand = raw_first ? b : a;
+            uint32_t raw_base = (uint32_t)raw.raw_ptr;
+            uint32_t sand_base = 0;
+
+            if (raw_first) {
+                raw_s.push_back(time_fn_once(raw, fn, raw_base, rounds));
+                sand_s.push_back(time_fn_once(sand, fn, sand_base, rounds));
+            }
+            else {
+                sand_s.push_back(time_fn_once(sand, fn, sand_base, rounds));
+                raw_s.push_back(time_fn_once(raw, fn, raw_base, rounds));
+            }
+            destroy(a);
+            destroy(b);
+        }
+        double ms = median(sand_s), mr = median(raw_s);
+        double ns_s = ms * 1e9 / ((double)rounds * (double)kElems);
+        double ns_r = mr * 1e9 / ((double)rounds * (double)kElems);
+        printf("%-10s  sandbox %7.3f s (%6.2f ns/el)  raw %7.3f s (%6.2f "
+               "ns/el)  speedup %.2fx\n",
+               fn, ms, ns_s, mr, ns_r, ms / mr);
+    }
+}
+
+/* Product-ish: two instances, same buffer.
+ * Raw: writer + reader share one host pointer (no copy).
+ * Sandbox: writer fills linear mem, host memcpy into reader mem, then read.
+ */
+static void
+bench_shared_pool(RunningMode mode, int rounds)
+{
+    printf("\n== shared_pool engine=%s rounds=%d ==\n", mode_name(mode),
+           rounds);
+
+    std::vector<double> sand_s, raw_s;
+    for (int s = 0; s < kSamples; s++) {
+        bool raw_first = (s & 1) != 0;
+
+        auto time_raw = [&]() -> double {
+            Env w{}, r{};
+            if (!setup(w, true, mode) || !setup(r, true, mode, false))
+                return -1;
+            /* Reader uses writer's buffer pointer. */
+            uint32_t ptr = (uint32_t)w.raw_ptr;
+            uint32_t sink = 0;
+            for (int i = 0; i < kWarmup; i++) {
+                run_named(w, "touch_i32", ptr, kElems, &sink);
+                run_named(r, "sum_i32", ptr, kElems, &sink);
+            }
+            double t0 = now_sec();
+            for (int i = 0; i < rounds; i++) {
+                run_named(w, "touch_i32", ptr, kElems, &sink);
+                run_named(r, "sum_i32", ptr, kElems, &sink);
+            }
+            double dt = now_sec() - t0;
+            destroy(w);
+            destroy(r);
+            return dt;
+        };
+
+        auto time_sand = [&]() -> double {
+            Env w{}, r{};
+            if (!setup(w, false, mode) || !setup(r, false, mode))
+                return -1;
+            void *wm = wasm_runtime_addr_app_to_native(w.inst, 0);
+            void *rm = wasm_runtime_addr_app_to_native(r.inst, 0);
+            uint32_t sink = 0;
+            for (int i = 0; i < kWarmup; i++) {
+                run_named(w, "touch_i32", 0, kElems, &sink);
+                memcpy(rm, wm, kBufBytes);
+                run_named(r, "sum_i32", 0, kElems, &sink);
+            }
+            double t0 = now_sec();
+            for (int i = 0; i < rounds; i++) {
+                run_named(w, "touch_i32", 0, kElems, &sink);
+                memcpy(rm, wm, kBufBytes);
+                run_named(r, "sum_i32", 0, kElems, &sink);
+            }
+            double dt = now_sec() - t0;
+            destroy(w);
+            destroy(r);
+            return dt;
+        };
+
+        if (raw_first) {
+            raw_s.push_back(time_raw());
+            sand_s.push_back(time_sand());
+        }
+        else {
+            sand_s.push_back(time_sand());
+            raw_s.push_back(time_raw());
+        }
+    }
+
+    double ms = median(sand_s), mr = median(raw_s);
+    printf("write+share+read  sandbox %7.3f s  raw %7.3f s  speedup %.2fx\n",
+           ms, mr, ms / mr);
+}
+
+#if defined(RAW_MEMORY_HAS_AOT_FIXTURE)
+static bool
+setup_aot(Env &e, bool raw)
+{
+    char err[128] = {};
+    unsigned size = 0;
+    const char *path =
+        raw ? "raw_mem_bench_raw.aot" : "raw_mem_bench_sandbox.aot";
+    e.buf = (unsigned char *)bh_read_file_to_buffer(path, &size);
+    if (!e.buf)
+        return false;
+    e.module = wasm_runtime_load(e.buf, size, err, sizeof(err));
+    if (!e.module) {
+        printf("aot load %s failed: %s\n", path, err);
+        return false;
+    }
+    e.inst = wasm_runtime_instantiate(e.module, 256 * 1024, 256 * 1024, err,
+                                      sizeof(err));
+    if (!e.inst)
+        return false;
+    if (raw) {
+        if (!wasm_runtime_set_address_mode(e.inst, WASM_ADDR_RAW))
+            return false;
+        WASMRawAllocHooks hooks = { map32_malloc, map32_free, map32_realloc,
+                                    map32_calloc, nullptr };
+        if (!wasm_runtime_set_raw_alloc_hooks(e.inst, &hooks))
+            return false;
+        e.raw_ptr =
+            wasm_runtime_module_malloc(e.inst, kBufBytes, &e.raw_native);
+        if (!e.raw_ptr)
+            return false;
+        for (uint32_t i = 0; i < kElems; i++)
+            ((uint32_t *)e.raw_native)[i] = i;
+    }
+    else {
+        void *mem = wasm_runtime_addr_app_to_native(e.inst, 0);
+        if (!mem)
+            return false;
+        for (uint32_t i = 0; i < kElems; i++)
+            ((uint32_t *)mem)[i] = i;
+    }
+    e.exec = wasm_runtime_create_exec_env(e.inst, 64 * 1024);
+    return e.exec != nullptr;
+}
+
+static void
+bench_aot_host(int rounds)
+{
+    printf("\n== aot host_churn rounds=%d samples=%d ==\n", rounds, kSamples);
+    std::vector<double> sand_s, raw_s;
+    for (int s = 0; s < kSamples; s++) {
+        bool raw_first = (s & 1) != 0;
+        Env a{}, b{};
+        if (!setup_aot(a, raw_first) || !setup_aot(b, !raw_first)) {
+            printf("aot setup failed (fixtures missing?)\n");
+            destroy(a);
+            destroy(b);
+            return;
+        }
+        Env &raw = raw_first ? a : b;
+        Env &sand = raw_first ? b : a;
+        if (raw_first) {
+            raw_s.push_back(
+                time_fn_once(raw, "host_churn", (uint32_t)raw.raw_ptr, rounds));
+            sand_s.push_back(time_fn_once(sand, "host_churn", 0, rounds));
+        }
+        else {
+            sand_s.push_back(time_fn_once(sand, "host_churn", 0, rounds));
+            raw_s.push_back(
+                time_fn_once(raw, "host_churn", (uint32_t)raw.raw_ptr, rounds));
+        }
+        destroy(a);
+        destroy(b);
+    }
+    double ms = median(sand_s), mr = median(raw_s);
+    printf("host_churn  sandbox %7.3f s  raw %7.3f s  speedup %.2fx\n", ms, mr,
+           ms / mr);
+}
+#endif
+
+int
+main(int argc, char **argv)
+{
+    int rounds = 400;
+    if (argc > 1)
+        rounds = atoi(argv[1]);
+    if (rounds < 1)
+        rounds = 1;
+
+    RuntimeInitArgs init{};
+    memset(&init, 0, sizeof(init));
+    init.mem_alloc_type = Alloc_With_System_Allocator;
+    init.native_module_name = "env";
+    init.n_native_symbols = 1;
+    init.native_symbols = g_natives;
+
+    if (!wasm_runtime_full_init(&init)) {
+        printf("runtime init failed\n");
+        return 1;
+    }
+
+    bench_pair(Mode_Interp, rounds);
+#if WASM_ENABLE_FAST_JIT != 0
+    bench_pair(Mode_Fast_JIT, rounds);
+    bench_shared_pool(Mode_Fast_JIT, rounds / 2 > 0 ? rounds / 2 : 1);
+#endif
+#if WASM_ENABLE_FAST_INTERP != 0 && WASM_ENABLE_FAST_JIT == 0
+    bench_shared_pool(Mode_Interp, rounds / 2 > 0 ? rounds / 2 : 1);
+#endif
+#if defined(RAW_MEMORY_HAS_AOT_FIXTURE)
+    bench_aot_host(rounds);
+#endif
+
+    wasm_runtime_destroy();
+    return 0;
+}

--- a/tests/unit/raw-memory/raw_memory_test.cc
+++ b/tests/unit/raw-memory/raw_memory_test.cc
@@ -1,0 +1,732 @@
+/*
+ * Copyright (C) 2026 Pymergetic | Rouven Raudzus. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include "test_helper.h"
+#include "gtest/gtest.h"
+
+#include "bh_read_file.h"
+#include "wasm_runtime_common.h"
+
+#include <cstring>
+#include <string>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <unordered_map>
+#include <vector>
+
+class raw_memory_test : public testing::Test {
+  protected:
+    WAMRRuntimeRAII<512 * 1024> runtime;
+};
+
+struct ModuleEnv {
+    wasm_exec_env_t exec_env = nullptr;
+    wasm_module_t module = nullptr;
+    wasm_module_inst_t inst = nullptr;
+    unsigned char *buf = nullptr;
+};
+
+static void
+destroy_env(ModuleEnv &e)
+{
+    if (e.exec_env)
+        wasm_runtime_destroy_exec_env(e.exec_env);
+    if (e.inst)
+        wasm_runtime_deinstantiate(e.inst);
+    if (e.module)
+        wasm_runtime_unload(e.module);
+    if (e.buf)
+        wasm_runtime_free(e.buf);
+    e = ModuleEnv{};
+}
+
+static bool
+load_file(ModuleEnv &e, const char *path, bool raw,
+          RunningMode mode = Mode_Interp)
+{
+    char error_buf[128] = {};
+    unsigned size = 0;
+    e.buf = (unsigned char *)bh_read_file_to_buffer(path, &size);
+    if (!e.buf)
+        return false;
+    e.module = wasm_runtime_load(e.buf, size, error_buf, sizeof(error_buf));
+    if (!e.module) {
+        printf("load %s failed: %s\n", path, error_buf);
+        return false;
+    }
+    e.inst = wasm_runtime_instantiate(e.module, 16 * 1024, 16 * 1024, error_buf,
+                                      sizeof(error_buf));
+    if (!e.inst) {
+        printf("instantiate %s failed: %s\n", path, error_buf);
+        return false;
+    }
+    if (raw) {
+        if (!wasm_runtime_set_address_mode(e.inst, WASM_ADDR_RAW))
+            return false;
+    }
+#if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0
+    if (!wasm_runtime_set_running_mode(e.inst, mode))
+        return false;
+#else
+    (void)mode;
+#endif
+    e.exec_env = wasm_runtime_create_exec_env(e.inst, 16 * 1024);
+    return e.exec_env != nullptr;
+}
+
+static bool
+load_env(ModuleEnv &e, bool raw, RunningMode mode = Mode_Interp)
+{
+    return load_file(e, "raw_mem_test.wasm", raw, mode);
+}
+
+/* Allocate in the low 32-bit VA so mem32 Raw Fast-JIT can use the pointer. */
+static void *
+map32_malloc(void *env, size_t size)
+{
+    (void)env;
+    size_t map_sz = size < 4096 ? 4096 : size;
+    void *p = mmap(nullptr, map_sz, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0);
+    return p == MAP_FAILED ? nullptr : p;
+}
+
+static void
+map32_free(void *env, void *ptr)
+{
+    (void)env;
+    if (ptr)
+        munmap(ptr, 4096);
+}
+
+static void *
+map32_realloc(void *env, void *ptr, size_t size)
+{
+    void *n = map32_malloc(env, size);
+    if (n && ptr) {
+        memcpy(n, ptr, size < 4096 ? size : 4096);
+        map32_free(env, ptr);
+    }
+    return n;
+}
+
+static void *
+map32_calloc(void *env, size_t nmemb, size_t size)
+{
+    size_t total = nmemb * size;
+    void *p = map32_malloc(env, total);
+    if (p)
+        memset(p, 0, total);
+    return p;
+}
+
+static bool
+install_map32_hooks(wasm_module_inst_t inst)
+{
+    WASMRawAllocHooks hooks = { map32_malloc, map32_free, map32_realloc,
+                                map32_calloc, nullptr };
+    return wasm_runtime_set_raw_alloc_hooks(inst, &hooks);
+}
+
+/*
+ * Embedder-style nest: each Raw node's hooks forward module_malloc to its
+ * parent instance (or map32 at the top). Demonstrates the policy chain —
+ * WAMR does not wire this automatically.
+ */
+struct NestNode {
+    const char *name = nullptr;
+    wasm_module_inst_t inst = nullptr;
+    NestNode *parent = nullptr;
+    bool parent_is_sandbox = false;
+    std::vector<std::string> *trace = nullptr;
+    std::unordered_map<void *, uint64_t> *sandbox_offs = nullptr;
+};
+
+static void
+nest_log(NestNode *n, const char *op)
+{
+    n->trace->push_back(std::string(n->name) + "." + op);
+}
+
+static void *
+nest_malloc(void *env, size_t size)
+{
+    NestNode *n = (NestNode *)env;
+    nest_log(n, "malloc");
+    if (!n->parent) {
+        nest_log(n, "malloc(map32 backer)");
+        return map32_malloc(nullptr, size);
+    }
+    n->trace->push_back(std::string("→ forward to ") + n->parent->name
+                        + ".module_malloc");
+    void *native = nullptr;
+    uint64_t app =
+        wasm_runtime_module_malloc(n->parent->inst, size, &native);
+    if (!native && !app)
+        return nullptr;
+    if (n->parent_is_sandbox) {
+        (*n->sandbox_offs)[native] = app;
+        return native;
+    }
+    return (void *)(uintptr_t)app;
+}
+
+static void
+nest_free(void *env, void *ptr)
+{
+    NestNode *n = (NestNode *)env;
+    if (!ptr)
+        return;
+    nest_log(n, "free");
+    if (!n->parent) {
+        map32_free(nullptr, ptr);
+        return;
+    }
+    uint64_t app = (uint64_t)(uintptr_t)ptr;
+    if (n->parent_is_sandbox) {
+        auto it = n->sandbox_offs->find(ptr);
+        if (it == n->sandbox_offs->end())
+            return;
+        app = it->second;
+        n->sandbox_offs->erase(it);
+    }
+    wasm_runtime_module_free(n->parent->inst, app);
+}
+
+static void *
+nest_realloc(void *env, void *ptr, size_t size)
+{
+    void *n = nest_malloc(env, size);
+    if (n && ptr) {
+        memcpy(n, ptr, size < 4096 ? size : 4096);
+        nest_free(env, ptr);
+    }
+    return n;
+}
+
+static void *
+nest_calloc(void *env, size_t nmemb, size_t size)
+{
+    size_t total = nmemb * size;
+    void *p = nest_malloc(env, total);
+    if (p)
+        memset(p, 0, total);
+    return p;
+}
+
+static bool
+install_nest_hooks(NestNode *node)
+{
+    WASMRawAllocHooks hooks = { nest_malloc, nest_free, nest_realloc,
+                                nest_calloc, node };
+    return wasm_runtime_set_raw_alloc_hooks(node->inst, &hooks);
+}
+
+static bool
+ptr_in_sandbox_linear(wasm_module_inst_t sandbox, void *native)
+{
+    wasm_memory_inst_t mem;
+    uint8_t *base;
+    uint8_t *addr;
+    uint64_t bytes;
+
+    if (!sandbox || !native)
+        return false;
+    /* Raw identity converters make offset round-trips meaningless. */
+    if (wasm_runtime_get_address_mode(sandbox) == WASM_ADDR_RAW)
+        return false;
+
+    mem = wasm_runtime_get_default_memory(sandbox);
+    if (!mem)
+        return false;
+    base = (uint8_t *)wasm_memory_get_base_address(mem);
+    bytes = (uint64_t)wasm_memory_get_cur_page_count(mem)
+            * (uint64_t)wasm_memory_get_bytes_per_page(mem);
+    addr = (uint8_t *)native;
+    return addr >= base && addr < base + bytes;
+}
+
+static void
+print_trace(const char *title, const std::vector<std::string> &trace)
+{
+    printf("\n== %s ==\n", title);
+    for (const auto &s : trace)
+        printf("  %s\n", s.c_str());
+}
+
+static void
+pack_i64(uint32_t *argv, uint64_t v)
+{
+    argv[0] = (uint32_t)v;
+    argv[1] = (uint32_t)(v >> 32);
+}
+
+static uint64_t
+unpack_i64(const uint32_t *argv)
+{
+    return ((uint64_t)argv[1] << 32) | argv[0];
+}
+
+TEST_F(raw_memory_test, sandbox_default_unchanged)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, false, Mode_Interp));
+    EXPECT_EQ(wasm_runtime_get_address_mode(e.inst), WASM_ADDR_SANDBOX);
+
+    void *native = nullptr;
+    uint64_t off = wasm_runtime_module_malloc(e.inst, 16, &native);
+    ASSERT_NE(off, 0u);
+    ASSERT_NE(native, nullptr);
+    EXPECT_EQ(wasm_runtime_addr_app_to_native(e.inst, off), native);
+    wasm_runtime_module_free(e.inst, off);
+    destroy_env(e);
+}
+
+TEST_F(raw_memory_test, raw_default_os_hooks_identity_malloc)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, true, Mode_Interp));
+    /* No custom hooks → os_malloc / os_free path. */
+    void *native = nullptr;
+    uint64_t ptr = wasm_runtime_module_malloc(e.inst, 64, &native);
+    ASSERT_NE(ptr, 0u);
+    ASSERT_EQ(native, (void *)(uintptr_t)ptr);
+    ASSERT_EQ(wasm_runtime_addr_app_to_native(e.inst, ptr), native);
+    wasm_runtime_module_free(e.inst, ptr);
+    destroy_env(e);
+}
+
+TEST_F(raw_memory_test, nest_alloc_chain_sandbox_vs_raw_outer)
+{
+    /*
+     * Embedder demo (not automatic): leaf → mid → outer.
+     *  A) outermost Raw  → process-like map32 backer
+     *  B) outermost Sandbox → bytes live in outer linear mem
+     *  C) Raw under sandbox with NO hooks → escapes outer linear
+     */
+    std::vector<std::string> trace;
+    std::unordered_map<void *, uint64_t> sandbox_offs;
+
+    /* --- A: outermost RAW --- */
+    {
+        ModuleEnv top{}, mid{}, leaf{};
+        ASSERT_TRUE(load_env(top, true, Mode_Interp));
+        ASSERT_TRUE(load_env(mid, true, Mode_Interp));
+        ASSERT_TRUE(load_env(leaf, true, Mode_Interp));
+
+        NestNode n_top{ "top(raw)", top.inst, nullptr, false, &trace,
+                        &sandbox_offs };
+        NestNode n_mid{ "mid(raw)", mid.inst, &n_top, false, &trace,
+                        &sandbox_offs };
+        NestNode n_leaf{ "leaf(raw)", leaf.inst, &n_mid, false, &trace,
+                         &sandbox_offs };
+        ASSERT_TRUE(install_nest_hooks(&n_top));
+        ASSERT_TRUE(install_nest_hooks(&n_mid));
+        ASSERT_TRUE(install_nest_hooks(&n_leaf));
+
+        trace.clear();
+        void *native = nullptr;
+        uint64_t ptr =
+            wasm_runtime_module_malloc(leaf.inst, 64, &native);
+        ASSERT_NE(ptr, 0u);
+        ASSERT_EQ(native, (void *)(uintptr_t)ptr);
+
+        print_trace("nest A: outermost RAW (process-like)", trace);
+        ASSERT_GE(trace.size(), 3u);
+        EXPECT_EQ(trace[0], "leaf(raw).malloc");
+        EXPECT_EQ(trace[1], "→ forward to mid(raw).module_malloc");
+        EXPECT_EQ(trace[2], "mid(raw).malloc");
+        EXPECT_EQ(trace[3], "→ forward to top(raw).module_malloc");
+        EXPECT_EQ(trace[4], "top(raw).malloc");
+        EXPECT_EQ(trace[5], "top(raw).malloc(map32 backer)");
+        /* Not inside any sandbox linear — host/map32 VA. */
+        EXPECT_FALSE(ptr_in_sandbox_linear(top.inst, native));
+
+        wasm_runtime_module_free(leaf.inst, ptr);
+        destroy_env(leaf);
+        destroy_env(mid);
+        destroy_env(top);
+    }
+
+    /* --- B: outermost SANDBOX --- */
+    {
+        ModuleEnv outer{}, mid{}, leaf{};
+        ASSERT_TRUE(load_env(outer, false, Mode_Interp));
+        ASSERT_TRUE(load_env(mid, true, Mode_Interp));
+        ASSERT_TRUE(load_env(leaf, true, Mode_Interp));
+
+        NestNode n_outer{ "outer(sandbox)", outer.inst, nullptr, false,
+                          &trace, &sandbox_offs };
+        NestNode n_mid{ "mid(raw)", mid.inst, &n_outer, true, &trace,
+                        &sandbox_offs };
+        NestNode n_leaf{ "leaf(raw)", leaf.inst, &n_mid, false, &trace,
+                         &sandbox_offs };
+        ASSERT_TRUE(install_nest_hooks(&n_mid));
+        ASSERT_TRUE(install_nest_hooks(&n_leaf));
+
+        trace.clear();
+        sandbox_offs.clear();
+        void *native = nullptr;
+        uint64_t ptr =
+            wasm_runtime_module_malloc(leaf.inst, 64, &native);
+        ASSERT_NE(ptr, 0u);
+        ASSERT_EQ(native, (void *)(uintptr_t)ptr);
+
+        print_trace("nest B: outermost SANDBOX (hooked into outer)",
+                    trace);
+        ASSERT_GE(trace.size(), 3u);
+        EXPECT_EQ(trace[0], "leaf(raw).malloc");
+        EXPECT_EQ(trace[1], "→ forward to mid(raw).module_malloc");
+        EXPECT_EQ(trace[2], "mid(raw).malloc");
+        EXPECT_EQ(trace[3],
+                  "→ forward to outer(sandbox).module_malloc");
+        EXPECT_TRUE(ptr_in_sandbox_linear(outer.inst, native));
+
+        /* Prove shared bytes via host ptr (mem32 leaf cannot i32-truncate
+         * a high VA into outer linear on 64-bit hosts). */
+        *(uint32_t *)native = 0x4E535401u;
+        EXPECT_EQ(*(uint32_t *)native, 0x4E535401u);
+
+        wasm_runtime_module_free(leaf.inst, ptr);
+        destroy_env(leaf);
+        destroy_env(mid);
+        destroy_env(outer);
+    }
+
+    /* --- C: Raw under sandbox, default hooks → escapes --- */
+    {
+        ModuleEnv outer{}, inner{};
+        ASSERT_TRUE(load_env(outer, false, Mode_Interp));
+        ASSERT_TRUE(load_env(inner, true, Mode_Interp));
+        /* No nest hooks on inner → os_malloc / identity. */
+        void *native = nullptr;
+        uint64_t ptr =
+            wasm_runtime_module_malloc(inner.inst, 64, &native);
+        ASSERT_NE(ptr, 0u);
+        printf("\n== nest C: Raw under sandbox, NO hooks (escapes) ==\n");
+        printf("  inner.malloc → default os_* native=%p\n", native);
+        EXPECT_FALSE(ptr_in_sandbox_linear(outer.inst, native));
+        wasm_runtime_module_free(inner.inst, ptr);
+        destroy_env(inner);
+        destroy_env(outer);
+    }
+}
+
+TEST_F(raw_memory_test, raw_malloc_identity_and_load_store_interp)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, true, Mode_Interp));
+    EXPECT_EQ(wasm_runtime_get_address_mode(e.inst), WASM_ADDR_RAW);
+    ASSERT_TRUE(install_map32_hooks(e.inst));
+
+    void *native = nullptr;
+    uint64_t ptr = wasm_runtime_module_malloc(e.inst, 16, &native);
+    ASSERT_NE(ptr, 0u);
+    ASSERT_EQ(native, (void *)(uintptr_t)ptr);
+    ASSERT_EQ(wasm_runtime_addr_app_to_native(e.inst, ptr), native);
+    ASSERT_LE(ptr, UINT32_MAX);
+
+    wasm_function_inst_t store =
+        wasm_runtime_lookup_function(e.inst, "store_i32");
+    wasm_function_inst_t load =
+        wasm_runtime_lookup_function(e.inst, "load_i32");
+    ASSERT_NE(store, nullptr);
+    ASSERT_NE(load, nullptr);
+
+    uint32_t argv[2] = { (uint32_t)ptr, 0xA1B2C3D4u };
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, store, 2, argv));
+    argv[0] = (uint32_t)ptr;
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, load, 1, argv));
+    EXPECT_EQ(argv[0], 0xA1B2C3D4u);
+
+    wasm_runtime_module_free(e.inst, ptr);
+    destroy_env(e);
+}
+
+TEST_F(raw_memory_test, raw_realloc_identity)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, true, Mode_Interp));
+    ASSERT_TRUE(install_map32_hooks(e.inst));
+
+    void *native = nullptr;
+    uint64_t ptr = wasm_runtime_module_malloc(e.inst, 8, &native);
+    ASSERT_NE(ptr, 0u);
+    memset(native, 0x5A, 8);
+
+    void *native2 = nullptr;
+    uint64_t ptr2 =
+        wasm_runtime_module_realloc(e.inst, ptr, 32, &native2);
+    ASSERT_NE(ptr2, 0u);
+    ASSERT_EQ(native2, (void *)(uintptr_t)ptr2);
+    EXPECT_EQ(((uint8_t *)native2)[0], 0x5A);
+
+    wasm_runtime_module_free(e.inst, ptr2);
+    destroy_env(e);
+}
+
+TEST_F(raw_memory_test, raw_memory_grow_returns_minus_one)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, true, Mode_Interp));
+    wasm_function_inst_t grow =
+        wasm_runtime_lookup_function(e.inst, "memory_grow");
+    ASSERT_NE(grow, nullptr);
+    uint32_t argv[2] = { 1u, 0 };
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, grow, 1, argv));
+#if WASM_ENABLE_MEMORY64 != 0
+    /* mem32 fixture still uses i32 grow result when MEMORY64 runtime loads
+     * mem32 modules. */
+#endif
+    EXPECT_EQ(argv[0], (uint32_t)-1);
+    destroy_env(e);
+}
+
+TEST_F(raw_memory_test, raw_bulk_fill_and_copy_interp)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, true, Mode_Interp));
+    ASSERT_TRUE(install_map32_hooks(e.inst));
+
+    void *native = nullptr;
+    uint64_t ptr = wasm_runtime_module_malloc(e.inst, 64, &native);
+    ASSERT_NE(ptr, 0u);
+    ASSERT_LE(ptr, UINT32_MAX);
+
+    wasm_function_inst_t fill =
+        wasm_runtime_lookup_function(e.inst, "memory_fill");
+    wasm_function_inst_t copy =
+        wasm_runtime_lookup_function(e.inst, "memory_copy");
+    wasm_function_inst_t load =
+        wasm_runtime_lookup_function(e.inst, "load_i32");
+    ASSERT_NE(fill, nullptr);
+    ASSERT_NE(copy, nullptr);
+
+    uint32_t argv[3] = { (uint32_t)ptr, 0xABu, 16u };
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, fill, 3, argv));
+    EXPECT_EQ(((uint8_t *)native)[0], 0xAB);
+    EXPECT_EQ(((uint8_t *)native)[15], 0xAB);
+
+    uint32_t dst = (uint32_t)ptr + 32;
+    argv[0] = dst;
+    argv[1] = (uint32_t)ptr;
+    argv[2] = 16u;
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, copy, 3, argv));
+    EXPECT_EQ(((uint8_t *)native)[32], 0xAB);
+
+    argv[0] = dst;
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, load, 1, argv));
+    EXPECT_EQ(argv[0] & 0xFFu, 0xABu);
+
+    wasm_runtime_module_free(e.inst, ptr);
+    destroy_env(e);
+}
+
+TEST_F(raw_memory_test, sandbox_memory_grow_can_succeed)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, false, Mode_Interp));
+    wasm_function_inst_t grow =
+        wasm_runtime_lookup_function(e.inst, "memory_grow");
+    ASSERT_NE(grow, nullptr);
+    uint32_t argv[1] = { 1u };
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, grow, 1, argv));
+    EXPECT_NE(argv[0], (uint32_t)-1);
+    destroy_env(e);
+}
+
+#if WASM_ENABLE_FAST_JIT != 0
+TEST_F(raw_memory_test, sandbox_fast_jit_smoke)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, false, Mode_Fast_JIT));
+    wasm_function_inst_t store =
+        wasm_runtime_lookup_function(e.inst, "store_i32");
+    uint32_t argv[2] = { 0, 0x11u };
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, store, 2, argv));
+    destroy_env(e);
+}
+
+
+TEST_F(raw_memory_test, raw_load_store_fast_jit)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, true, Mode_Fast_JIT));
+    ASSERT_TRUE(install_map32_hooks(e.inst));
+
+    void *native = nullptr;
+    uint64_t ptr = wasm_runtime_module_malloc(e.inst, 16, &native);
+    ASSERT_NE(ptr, 0u);
+    ASSERT_NE(native, nullptr);
+    memset(native, 0, 16);
+
+    wasm_function_inst_t store =
+        wasm_runtime_lookup_function(e.inst, "store_i32");
+    wasm_function_inst_t load =
+        wasm_runtime_lookup_function(e.inst, "load_i32");
+    ASSERT_NE(store, nullptr);
+    ASSERT_NE(load, nullptr);
+
+    uint32_t argv[2] = { (uint32_t)ptr, 0x55667788u };
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, store, 2, argv));
+    ASSERT_EQ(*(uint32_t *)native, 0x55667788u);
+
+    argv[0] = (uint32_t)ptr;
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, load, 1, argv));
+    EXPECT_EQ(argv[0], 0x55667788u);
+
+    wasm_runtime_module_free(e.inst, ptr);
+    destroy_env(e);
+}
+
+
+TEST_F(raw_memory_test, raw_memory_grow_fast_jit_returns_minus_one)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, true, Mode_Fast_JIT));
+    wasm_function_inst_t grow =
+        wasm_runtime_lookup_function(e.inst, "memory_grow");
+    ASSERT_NE(grow, nullptr);
+    uint32_t argv[1] = { 1u };
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, grow, 1, argv));
+    EXPECT_EQ(argv[0], (uint32_t)-1);
+    destroy_env(e);
+}
+
+TEST_F(raw_memory_test, raw_bulk_fill_fast_jit)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_env(e, true, Mode_Fast_JIT));
+    ASSERT_TRUE(install_map32_hooks(e.inst));
+
+    void *native = nullptr;
+    uint64_t ptr = wasm_runtime_module_malloc(e.inst, 32, &native);
+    ASSERT_NE(ptr, 0u);
+
+    wasm_function_inst_t fill =
+        wasm_runtime_lookup_function(e.inst, "memory_fill");
+    uint32_t argv[3] = { (uint32_t)ptr, 0xCDu, 8u };
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, fill, 3, argv));
+    EXPECT_EQ(((uint8_t *)native)[0], 0xCD);
+    EXPECT_EQ(((uint8_t *)native)[7], 0xCD);
+    wasm_runtime_module_free(e.inst, ptr);
+    destroy_env(e);
+}
+#endif
+
+#if defined(RAW_MEMORY_HAS_AOT_FIXTURE)
+TEST_F(raw_memory_test, raw_aot_load_store)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_file(e, "raw_mem_test.aot", true, Mode_Interp));
+    ASSERT_TRUE(install_map32_hooks(e.inst));
+
+    void *native = nullptr;
+    uint64_t ptr = wasm_runtime_module_malloc(e.inst, 16, &native);
+    ASSERT_NE(ptr, 0u);
+    ASSERT_LE(ptr, UINT32_MAX);
+
+    wasm_function_inst_t store =
+        wasm_runtime_lookup_function(e.inst, "store_i32");
+    wasm_function_inst_t load =
+        wasm_runtime_lookup_function(e.inst, "load_i32");
+    ASSERT_NE(store, nullptr);
+    ASSERT_NE(load, nullptr);
+
+    uint32_t argv[2] = { (uint32_t)ptr, 0xDEADBEEFu };
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, store, 2, argv));
+    argv[0] = (uint32_t)ptr;
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, load, 1, argv));
+    EXPECT_EQ(argv[0], 0xDEADBEEFu);
+
+    wasm_function_inst_t grow =
+        wasm_runtime_lookup_function(e.inst, "memory_grow");
+    ASSERT_NE(grow, nullptr);
+    argv[0] = 1u;
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, grow, 1, argv));
+    EXPECT_EQ(argv[0], (uint32_t)-1);
+
+    wasm_runtime_module_free(e.inst, ptr);
+    destroy_env(e);
+}
+#endif
+
+#if WASM_ENABLE_MEMORY64 != 0
+TEST_F(raw_memory_test, raw_memory64_load_store_full_pointer)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_file(e, "raw_mem64_test.wasm", true, Mode_Interp));
+    /* Default os_* hooks: full 64-bit host pointers are valid guest i64s. */
+    void *native = nullptr;
+    uint64_t ptr = wasm_runtime_module_malloc(e.inst, 32, &native);
+    ASSERT_NE(ptr, 0u);
+    ASSERT_EQ(native, (void *)(uintptr_t)ptr);
+
+    wasm_function_inst_t store =
+        wasm_runtime_lookup_function(e.inst, "store_i32");
+    wasm_function_inst_t load =
+        wasm_runtime_lookup_function(e.inst, "load_i32");
+    ASSERT_NE(store, nullptr);
+    ASSERT_NE(load, nullptr);
+
+    uint32_t argv[4] = {};
+    pack_i64(argv, ptr);
+    argv[2] = 0x11223344u;
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, store, 3, argv));
+
+    pack_i64(argv, ptr);
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, load, 2, argv));
+    EXPECT_EQ(argv[0], 0x11223344u);
+
+    wasm_function_inst_t fill =
+        wasm_runtime_lookup_function(e.inst, "memory_fill");
+    pack_i64(argv, ptr);
+    argv[2] = 0x7Eu;
+    pack_i64(argv + 3, 8);
+    /* fill(i64,i32,i64) → 2+1+2 = 5 cells */
+    uint32_t fargv[5] = {};
+    pack_i64(fargv, ptr);
+    fargv[2] = 0x7Eu;
+    pack_i64(fargv + 3, 8);
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, fill, 5, fargv));
+    EXPECT_EQ(((uint8_t *)native)[0], 0x7E);
+
+    wasm_function_inst_t grow =
+        wasm_runtime_lookup_function(e.inst, "memory_grow");
+    uint32_t gargv[2] = {};
+    pack_i64(gargv, 1);
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, grow, 2, gargv));
+    EXPECT_EQ(unpack_i64(gargv), (uint64_t)-1);
+
+    wasm_runtime_module_free(e.inst, ptr);
+    destroy_env(e);
+}
+
+#if defined(RAW_MEMORY_HAS_AOT64_FIXTURE)
+TEST_F(raw_memory_test, raw_memory64_aot_load_store)
+{
+    ModuleEnv e{};
+    ASSERT_TRUE(load_file(e, "raw_mem64_test.aot", true, Mode_Interp));
+
+    void *native = nullptr;
+    uint64_t ptr = wasm_runtime_module_malloc(e.inst, 16, &native);
+    ASSERT_NE(ptr, 0u);
+
+    wasm_function_inst_t store =
+        wasm_runtime_lookup_function(e.inst, "store_i32");
+    wasm_function_inst_t load =
+        wasm_runtime_lookup_function(e.inst, "load_i32");
+    uint32_t argv[4] = {};
+    pack_i64(argv, ptr);
+    argv[2] = 0xCAFEBABEu;
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, store, 3, argv));
+    pack_i64(argv, ptr);
+    ASSERT_TRUE(wasm_runtime_call_wasm(e.exec_env, load, 2, argv));
+    EXPECT_EQ(argv[0], 0xCAFEBABEu);
+    wasm_runtime_module_free(e.inst, ptr);
+    destroy_env(e);
+}
+#endif
+#endif /* WASM_ENABLE_MEMORY64 */

--- a/tests/unit/raw-memory/run_matrix.sh
+++ b/tests/unit/raw-memory/run_matrix.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Pymergetic | Rouven Raudzus. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Build and run Raw memory unit tests for every engine profile.
+set -euo pipefail
+
+SRC_DIR=${1:-$(cd "$(dirname "$0")" && pwd)}
+OUT_DIR=${2:-/tmp/wamr-raw-memory-matrix}
+
+profiles=(fast_jit fast_interp memory64)
+failed=0
+
+for profile in "${profiles[@]}"; do
+  build="$OUT_DIR/$profile"
+  echo "======== PROFILE $profile ========"
+  mkdir -p "$build"
+  aot_args=()
+  if [[ "$profile" == "fast_interp" ]]; then
+    aot_args+=(-DRAW_MEMORY_TEST_BUILD_AOT=OFF)
+  fi
+  cmake -S "$SRC_DIR" -B "$build" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DWAMR_BUILD_PLATFORM=linux \
+    -DRAW_MEMORY_TEST_PROFILE="$profile" \
+    "${aot_args[@]}" \
+    ${LLVM_DIR:+-DLLVM_DIR=$LLVM_DIR}
+  cmake --build "$build" -j"$(nproc)"
+  (cd "$build" && ./raw_memory_test) || failed=1
+done
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "Raw memory matrix: FAILURE" >&2
+  exit 1
+fi
+echo "Raw memory matrix: all profiles passed"

--- a/tests/unit/raw-memory/wasm-apps/gen_raw_mem_bench_wasm.py
+++ b/tests/unit/raw-memory/wasm-apps/gen_raw_mem_bench_wasm.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Pymergetic | Rouven Raudzus. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Emit raw_mem_bench.wasm for Raw vs sandbox microbenches."""
+
+import sys
+
+
+def uleb(n: int) -> bytes:
+    out = bytearray()
+    while True:
+        b = n & 0x7F
+        n >>= 7
+        if n:
+            out.append(b | 0x80)
+        else:
+            out.append(b)
+            break
+    return bytes(out)
+
+
+def section(sec_id: int, payload: bytes) -> bytes:
+    return bytes([sec_id]) + uleb(len(payload)) + payload
+
+
+def export(name: str, kind: int, idx: int) -> bytes:
+    nb = name.encode()
+    return uleb(len(nb)) + nb + bytes([kind]) + uleb(idx)
+
+
+def name_bytes(s: str) -> bytes:
+    b = s.encode()
+    return uleb(len(b)) + b
+
+
+def func_body(locals_payload: bytes, body: bytes) -> bytes:
+    payload = locals_payload + body
+    return uleb(len(payload)) + payload
+
+
+def loop_load_body(with_host_call: bool) -> bytes:
+    """for i in 0..n: acc += load_or_host(base+i*4)"""
+    # after computing addr on stack:
+    if with_host_call:
+        # call import 0 (host_ldadd)
+        access = bytes([0x10, 0x00])
+    else:
+        access = bytes([0x28, 0x02, 0x00])  # i32.load
+    return bytes(
+        [
+            0x02,
+            0x40,
+            0x03,
+            0x40,
+            0x20,
+            0x02,
+            0x20,
+            0x01,
+            0x4F,
+            0x0D,
+            0x01,
+            0x20,
+            0x03,
+            0x20,
+            0x00,
+            0x20,
+            0x02,
+            0x41,
+            0x02,
+            0x74,
+            0x6A,
+        ]
+    ) + access + bytes(
+        [
+            0x6A,
+            0x21,
+            0x03,
+            0x20,
+            0x02,
+            0x41,
+            0x01,
+            0x6A,
+            0x21,
+            0x02,
+            0x0C,
+            0x00,
+            0x0B,
+            0x0B,
+            0x20,
+            0x03,
+            0x0B,
+        ]
+    )
+
+
+def touch_body() -> bytes:
+    return bytes(
+        [
+            0x02,
+            0x40,
+            0x03,
+            0x40,
+            0x20,
+            0x02,
+            0x20,
+            0x01,
+            0x4F,
+            0x0D,
+            0x01,
+            0x20,
+            0x00,
+            0x20,
+            0x02,
+            0x41,
+            0x02,
+            0x74,
+            0x6A,
+            0x28,
+            0x02,
+            0x00,  # v
+            0x20,
+            0x00,
+            0x20,
+            0x02,
+            0x41,
+            0x02,
+            0x74,
+            0x6A,
+            0x20,
+            0x00,
+            0x20,
+            0x02,
+            0x41,
+            0x02,
+            0x74,
+            0x6A,
+            0x28,
+            0x02,
+            0x00,
+            0x41,
+            0x01,
+            0x6A,
+            0x36,
+            0x02,
+            0x00,
+            0x20,
+            0x03,
+            0x6A,
+            0x21,
+            0x03,
+            0x20,
+            0x02,
+            0x41,
+            0x01,
+            0x6A,
+            0x21,
+            0x02,
+            0x0C,
+            0x00,
+            0x0B,
+            0x0B,
+            0x20,
+            0x03,
+            0x0B,
+        ]
+    )
+
+
+def build() -> bytes:
+    # type0: (i32)->i32  host
+    # type1: (i32,i32)->i32  benches
+    types = (
+        uleb(2)
+        + bytes([0x60, 1, 0x7F, 1, 0x7F])
+        + bytes([0x60, 2, 0x7F, 0x7F, 1, 0x7F])
+    )
+    imports = (
+        uleb(1)
+        + name_bytes("env")
+        + name_bytes("host_ldadd")
+        + bytes([0x00])
+        + uleb(0)
+    )
+    # defined: sum=1, touch=2, host_churn=3  (import takes func idx 0)
+    funcs = uleb(3) + uleb(1) + uleb(1) + uleb(1)
+    mems = uleb(1) + bytes([0x00]) + uleb(4)
+    exports = (
+        uleb(4)
+        + export("mem", 2, 0)
+        + export("sum_i32", 0, 1)
+        + export("touch_i32", 0, 2)
+        + export("host_churn", 0, 3)
+    )
+    locs = bytes([0x01, 0x02, 0x7F])
+    code = (
+        uleb(3)
+        + func_body(locs, loop_load_body(False))
+        + func_body(locs, touch_body())
+        + func_body(locs, loop_load_body(True))
+    )
+
+    mod = bytearray(b"\x00asm\x01\x00\x00\x00")
+    mod += section(1, types)
+    mod += section(2, imports)
+    mod += section(3, funcs)
+    mod += section(5, mems)
+    mod += section(7, exports)
+    mod += section(10, code)
+    return bytes(mod)
+
+
+def main() -> None:
+    out = sys.argv[1] if len(sys.argv) > 1 else "raw_mem_bench.wasm"
+    data = build()
+    with open(out, "wb") as f:
+        f.write(data)
+    print(f"wrote {out} ({len(data)} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/raw-memory/wasm-apps/gen_raw_mem_test_wasm.py
+++ b/tests/unit/raw-memory/wasm-apps/gen_raw_mem_test_wasm.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Pymergetic | Rouven Raudzus. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Emit raw_mem_test.wasm / raw_mem64_test.wasm fixtures (no wat2wasm)."""
+
+import sys
+
+
+def uleb(n: int) -> bytes:
+    out = bytearray()
+    while True:
+        b = n & 0x7F
+        n >>= 7
+        if n:
+            out.append(b | 0x80)
+        else:
+            out.append(b)
+            break
+    return bytes(out)
+
+
+def section(sec_id: int, payload: bytes) -> bytes:
+    return bytes([sec_id]) + uleb(len(payload)) + payload
+
+
+def export(name: str, kind: int, idx: int) -> bytes:
+    nb = name.encode()
+    return uleb(len(nb)) + nb + bytes([kind]) + uleb(idx)
+
+
+def func_body(body: bytes) -> bytes:
+    payload = uleb(0) + body
+    return uleb(len(payload)) + payload
+
+
+def build_mem32() -> bytes:
+    # types: (i32)->i32, (i32,i32)->, (i32)->i32, (i32,i32,i32)->, (i32,i32,i32)->
+    types = (
+        uleb(5)
+        + bytes([0x60, 1, 0x7F, 1, 0x7F])  # load
+        + bytes([0x60, 2, 0x7F, 0x7F, 0])  # store
+        + bytes([0x60, 1, 0x7F, 1, 0x7F])  # grow
+        + bytes([0x60, 3, 0x7F, 0x7F, 0x7F, 0])  # fill
+        + bytes([0x60, 3, 0x7F, 0x7F, 0x7F, 0])  # copy
+    )
+    funcs = uleb(5) + uleb(0) + uleb(1) + uleb(2) + uleb(3) + uleb(4)
+    mems = uleb(1) + bytes([0x00]) + uleb(1)
+    exports = (
+        uleb(6)
+        + export("mem", 2, 0)
+        + export("load_i32", 0, 0)
+        + export("store_i32", 0, 1)
+        + export("memory_grow", 0, 2)
+        + export("memory_fill", 0, 3)
+        + export("memory_copy", 0, 4)
+    )
+    load_body = bytes([0x20, 0x00, 0x28, 0x02, 0x00, 0x0B])
+    store_body = bytes([0x20, 0x00, 0x20, 0x01, 0x36, 0x02, 0x00, 0x0B])
+    grow_body = bytes([0x20, 0x00, 0x40, 0x00, 0x0B])
+    # memory.fill: dst, val, len ; opcode 0xFC 0x0B memidx
+    fill_body = bytes(
+        [0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xFC, 0x0B, 0x00, 0x0B]
+    )
+    # memory.copy: dst, src, len ; opcode 0xFC 0x0A dst src
+    copy_body = bytes(
+        [0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xFC, 0x0A, 0x00, 0x00, 0x0B]
+    )
+    code = (
+        uleb(5)
+        + func_body(load_body)
+        + func_body(store_body)
+        + func_body(grow_body)
+        + func_body(fill_body)
+        + func_body(copy_body)
+    )
+
+    mod = bytearray(b"\x00asm\x01\x00\x00\x00")
+    mod += section(1, types)
+    mod += section(3, funcs)
+    mod += section(5, mems)
+    mod += section(7, exports)
+    mod += section(10, code)
+    return bytes(mod)
+
+
+def build_mem64() -> bytes:
+    # i64 address load/store/grow/fill/copy
+    types = (
+        uleb(5)
+        + bytes([0x60, 1, 0x7E, 1, 0x7F])  # load (i64)->i32
+        + bytes([0x60, 2, 0x7E, 0x7F, 0])  # store (i64,i32)->
+        + bytes([0x60, 1, 0x7E, 1, 0x7E])  # grow (i64)->i64
+        + bytes([0x60, 3, 0x7E, 0x7F, 0x7E, 0])  # fill (i64,i32,i64)->
+        + bytes([0x60, 3, 0x7E, 0x7E, 0x7E, 0])  # copy (i64,i64,i64)->
+    )
+    funcs = uleb(5) + uleb(0) + uleb(1) + uleb(2) + uleb(3) + uleb(4)
+    # memory64: flags 0x04 (i64 limits), min=1
+    mems = uleb(1) + bytes([0x04]) + uleb(1)
+    exports = (
+        uleb(6)
+        + export("mem", 2, 0)
+        + export("load_i32", 0, 0)
+        + export("store_i32", 0, 1)
+        + export("memory_grow", 0, 2)
+        + export("memory_fill", 0, 3)
+        + export("memory_copy", 0, 4)
+    )
+    # i64.load32_u offset align - use i32.load with memory64 addr: 0x28
+    load_body = bytes([0x20, 0x00, 0x28, 0x02, 0x00, 0x0B])
+    store_body = bytes([0x20, 0x00, 0x20, 0x01, 0x36, 0x02, 0x00, 0x0B])
+    grow_body = bytes([0x20, 0x00, 0x40, 0x00, 0x0B])
+    fill_body = bytes(
+        [0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xFC, 0x0B, 0x00, 0x0B]
+    )
+    copy_body = bytes(
+        [0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xFC, 0x0A, 0x00, 0x00, 0x0B]
+    )
+    code = (
+        uleb(5)
+        + func_body(load_body)
+        + func_body(store_body)
+        + func_body(grow_body)
+        + func_body(fill_body)
+        + func_body(copy_body)
+    )
+
+    mod = bytearray(b"\x00asm\x01\x00\x00\x00")
+    mod += section(1, types)
+    mod += section(3, funcs)
+    mod += section(5, mems)
+    mod += section(7, exports)
+    mod += section(10, code)
+    return bytes(mod)
+
+
+def main() -> int:
+    if len(sys.argv) not in (2, 3):
+        print(
+            f"usage: {sys.argv[0]} <out.wasm> [--mem64]",
+            file=sys.stderr,
+        )
+        return 2
+    mem64 = len(sys.argv) == 3 and sys.argv[2] == "--mem64"
+    data = build_mem64() if mem64 else build_mem32()
+    with open(sys.argv[1], "wb") as f:
+        f.write(data)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -56,6 +56,7 @@ add_definitions(-DWASM_ENABLE_PERF_PROFILING=1)
 add_definitions(-DWASM_ENABLE_LOAD_CUSTOM_SECTION=1)
 add_definitions(-DWASM_ENABLE_MODULE_INST_CONTEXT=1)
 add_definitions(-DWASM_ENABLE_MEMORY64=1)
+add_definitions(-DWASM_ENABLE_RAW_MEMORY=1)
 add_definitions(-DWASM_ENABLE_EXTENDED_CONST_EXPR=1)
 
 add_definitions(-DWASM_ENABLE_GC=1)

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -222,6 +222,8 @@ print_help()
     printf("  --enable-shared-heap      Enable shared heap feature, assuming only one shared heap will be attached\n");
     printf("  --enable-shared-chain     Enable shared heap chain feature, works for more than one shared heap\n");
     printf("                            WARNING: enable this feature will largely increase code size\n");
+    printf("  --enable-raw-memory       Bake Raw address mode (guest ints are host pointers)\n");
+    printf("                            WARNING: disables linear-memory isolation; only for trusted modules\n");
     printf("  -v=n                      Set log verbose level (0 to 5, default is 2), larger with more log\n");
     printf("  --version                 Show version information\n");
     printf("  --llvm-version            Show LLVM version information\n");
@@ -689,6 +691,9 @@ main(int argc, char *argv[])
         else if (!strcmp(argv[0], "--enable-shared-chain")) {
             option.enable_shared_chain = true;
         }
+        else if (!strcmp(argv[0], "--enable-raw-memory")) {
+            option.enable_raw_memory = true;
+        }
         else if (!strcmp(argv[0], "--version")) {
             uint32 major, minor, patch;
             wasm_runtime_get_version(&major, &minor, &patch);
@@ -762,6 +767,12 @@ main(int argc, char *argv[])
                     "bounds control");
         option.enable_shared_heap = false;
         option.bounds_checks = true;
+    }
+
+    if (option.enable_raw_memory
+        && (option.enable_shared_heap || option.enable_shared_chain)) {
+        printf("Error: --enable-raw-memory is incompatible with shared heap\n");
+        goto fail0;
     }
 
     if (option.enable_bulk_memory) {


### PR DESCRIPTION
# PR: Raw address mode (`WAMR_BUILD_RAW_MEMORY`)

## Sorry / not sorry

We're sorry for poking a hole in WAMR's beloved linear-memory isolation.

We're not sorry about what that hole makes possible when you **intentionally**
opt in: wasm as a **code container** where you call everything as local and
access everything as local — closely tied pieces in one VA — instead of a
nest of sandboxed tenants that each own (and often waste) their own address
space. Speedups are a nice side effect of dropping that theater.

Default builds are unchanged. Sandbox stays the default. Raw is build-gated,
per-instance, and documented as trusted-only.

Mutually exclusive with Shared Heap — not because we couldn't wire both, but
because it barely makes sense: Shared Heap exists to punch a shared window
*through* sandbox isolation. In Raw, guest ints are already host pointers in
one VA; the whole heap is shared. Stacking both is “shared, but also shared.”

## Why (the product)

Sandbox isolation is the right default for untrusted modules. For products
that already trust their wasm (same process, same team, same ship), the
pain is **architectural**, not “we need 2× fewer nanoseconds”:

- **Call everything as local** — guest `*` / `$` args *are* host pointers;
  host and sibling modules talk without offset↔native theater.
- **Access everything as local** — one process VA; allocators / arenas /
  shared buffers live where C would put them.
- **Code container, not tenant farm** — modules are compilation units /
  plugins inside one app. No private linear memory per sibling “just
  because wasm.”

Portable IR + load/JIT/AOT, without pretending siblings need mem fences.

## One VA, optional alloc chain

Address mode is **per instance**. There is only one real address space: the
**process VA**. Nested Raw does not invent nested VAs.

Raw sees host pointers. A sandboxed outer that loads a Raw inner does **not**
give the inner “outer’s linear memory as its universe,” and outer isolation
does **not** wrap Raw. Default Raw `module_malloc` is `os_*` (process heap)
unless the embedder says otherwise.

**Alloc hooks are embedder policy**, not automatic hierarchy. The loader
decides what the guest’s heap *is*:

- **Host / base alloc** — default `os_*` or your process allocator (full
  VA; Linux-process shape).
- **Parent borders** — forward into a sandboxed outer’s
  `module_malloc` / linear mem (cooperative “live in my blob”).
- **Separate arena** — hooks that only hand out pointers from some other
  region (mmap slab, pool, Metal arena, …) that lives wherever you put it.

```
process VA
├── A  outermost Raw  (Linux-process shape)
│     top(raw) ──os_*/mmap──► host heap          ← owns the pool
│       └── mid(raw)  hooks → top
│             └── leaf(raw)  hooks → mid
│                   malloc walks leaf → mid → top
│
├── B  outermost Sandbox  (cooperative “live in my blob”)
│     outer(sandbox) ──► outer linear memory     ← owns the pool
│       └── mid(raw)  hooks → outer.module_malloc
│             └── leaf(raw)  hooks → mid
│                   bytes land inside outer’s borders
│
├── C  separate arena  (loader-drawn box anywhere in VA)
│     arena / mmap slab                          ← owns the pool
│       └── child(raw)  hooks → arena only
│
└── ✗  Raw under sandbox, NO hooks
      outer(sandbox)  linear mem
      inner(raw) ──os_*──► process heap          ← escapes outer
```

A loader may chain levels (`leaf → mid → top`) so whoever actually backs
memory owns the pool and everyone below shares that VA. If the **top** is
Raw with `os_*` / mmap, the stack behaves like a normal Linux process —
wasm is just more code in one address space.

Hooking only steers **cooperative** heap traffic. It is not a security
boundary: forge a pointer and you are still on process VA.

Demo (prints the chain): unit test
`nest_alloc_chain_sandbox_vs_raw_outer` — outermost Raw vs outermost
sandbox vs unhooked escape. Details: [`doc/raw_memory.md`](raw_memory.md)
§ Nested loaders.

## Nice side effect: measured speedups

Speed is what you get when you stop paying taxes you did not want — not
the reason to ship Raw. Microbench
`tests/unit/raw-memory/raw_memory_bench` (Release, x86_64, 16 384 elems ×
300 rounds, order-swapped medians of 5).

| Engine | Config | Workload | Sandbox | Raw | Speedup |
|--------|--------|----------|---------|-----|---------|
| Fast-JIT | HW bounds | `host_churn` (wasm→host `*` arg) | 11.8 ns/el | 4.3 ns/el | **~2.7×** |
| Fast-JIT | soft bounds | `host_churn` | 11.5 ns/el | 4.4 ns/el | **~2.6×** |
| AOT | soft (`wamrc` ± `--enable-raw-memory`) | `host_churn` | 0.294 s | 0.214 s | **~1.4×** |
| Fast-interp | soft bounds | `host_churn` | 83.3 ns/el | 68.6 ns/el | ~1.2× |
| Fast-JIT | HW / soft | in-wasm `sum_i32` / `touch_i32` | ~2.5–3.2 ns/el | ~2.5–3.0 ns/el | ~1.0–1.09× |
| Fast-JIT | soft | `shared_pool` (2 mods, write+share+read) | 0.015 s | 0.014 s | ~1.1× |

Reading the table honestly:

- **Host pointer calls** (Fast-JIT) show the convert tax clearly once the
  rest of the path is already lean.
- **Fast-interp ~1.2×** is small because the baseline is fat: dispatch
  dominates, so removing convert is a modest fraction of a slow path
  (same absolute save looks bigger under Fast-JIT).
- **In-wasm loads under HW bounds** ≈ parity — isolation was already
  cheap there.
- **`shared_pool`** wall time on a tiny buffer is still the write/read
  loops; the real win is no private linear mem / no copy architecture.

```bash
cmake -S tests/unit/raw-memory -B build-bench -DCMAKE_BUILD_TYPE=Release \
  -DRAW_MEMORY_TEST_PROFILE=fast_jit
cmake --build build-bench --target raw_memory_bench
(cd build-bench && ./raw_memory_bench 300)
```

## What

| Piece | Behavior |
|-------|----------|
| Build | `-DWAMR_BUILD_RAW_MEMORY=1` (default `0`) |
| API | `wasm_runtime_set_address_mode(inst, WASM_ADDR_RAW)` + optional alloc hooks |
| Engines | Classic / fast interp, Fast-JIT (mode baked at compile), AOT via `wamrc --enable-raw-memory` |
| `memory.grow` | returns `-1` in Raw |
| Shared Heap | cmake-refused with Raw (redundant once the whole VA is shared) |
| Hosts | 32- and 64-bit (mem32 on 64-bit still needs pointers that fit in `i32`) |

Details: [`doc/raw_memory.md`](raw_memory.md).

## Trust model

Raw has **no** linear-memory isolation. One bad store can trash the process.
Only load modules compiled/understood for host pointers. A sandboxed parent
does **not** contain a Raw child. If you need tenants, keep sandbox (on
every instance that must stay a tenant).

## Test plan

```bash
# refuse
cmake ... -DWAMR_BUILD_RAW_MEMORY=1 -DWAMR_BUILD_SHARED_HEAP=1   # must FATAL

# product-mini
cmake ... -DWAMR_BUILD_RAW_MEMORY=0   # build
cmake ... -DWAMR_BUILD_RAW_MEMORY=1   # build (x86_64 and X86_32)

# unit matrix
tests/unit/raw-memory/run_matrix.sh
# incl. nest_alloc_chain_sandbox_vs_raw_outer (hook chain demo)
# fast_jit / fast_interp / memory64 — load/store, bulk, grow→-1, hooks, AOT
```

Verified locally before this PR: refuse Shared+Raw; PM RAW=0/1 + Fast-JIT
+ X86_32; matrix **13+8+11**; nest A/B/escape; Fast-JIT sandbox/raw smoke
×80; rebench soft/HW Fast-JIT + AOT + fast-interp (numbers above).

Made with [Cursor](https://cursor.com)