### PR TITLE
ci: harden approval-gated required checks

### DIFF
--- a/.github/workflows/compilation_on_android.yml
+++ b/.github/workflows/compilation_on_android.yml
@@ -22,8 +22,12 @@ on:
       - "dev/**"
     # Narrower than the ubuntu workflow: android builds iwasm only, so
     # wamr-compiler, the test suites and wamr-ide are irrelevant here.
+    # Every input the result depends on must be listed, including the gate
+    # machinery - see the same block in compilation_on_ubuntu.yml.
     paths:
+      - ".github/scripts/**"
       - ".github/workflows/compilation_on_android.yml"
+      - ".github/workflows/gate.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"

--- a/.github/workflows/compilation_on_ubuntu.yml
+++ b/.github/workflows/compilation_on_ubuntu.yml
@@ -13,23 +13,39 @@ on:
     # run=false unless the repository is a fork), so this filter only trims a
     # fork's mirrored copies of the maintainer branches - re-pushing main,
     # release/** or dev/** to a fork is a sync, not work worth building.
+    #
     # NOTE: do not name a fork feature branch main, release/*, or dev/* -
     # its push CI would be silently skipped by this filter.
     branches-ignore:
       - "main"
       - "release/**"
       - "dev/**"
+    # This list is also what the approval gate re-applies on
+    # pull_request_review (see gate.yml). Because `required` below treats a
+    # skipped job as success, anything missing here makes `ubuntu CI` go green
+    # without building - so every input this workflow's result depends on must
+    # be listed, including the reusable workflows and composite actions it
+    # calls and the gate machinery that decides whether it runs at all.
     paths:
+      - ".github/actions/**"
+      - ".github/scripts/**"
       - ".github/workflows/build_llvm_libraries.yml"
+      - ".github/workflows/check_version_h.yml"
       - ".github/workflows/compilation_on_ubuntu.yml"
+      - ".github/workflows/gate.yml"
       - "build-scripts/**"
       - "core/**"
+      # Only README.md and install_tensorflow.sh are tracked here; the latter
+      # serves samples/workload, which is excluded below. Everything else under
+      # core/deps is a downloaded or built dependency.
       - "!core/deps/**"
       - "product-mini/**"
       - "samples/**"
       - "!samples/workload/**"
       - "tests/wamr-test-suites/**"
       - "tests/unit/**"
+      # Source of the build_regression_tests job (tests/regression/ba-issues).
+      - "tests/regression/**"
       - "wamr-compiler/**"
       - "test-tools/wamr-ide/**"
   # Upstream CI: only spend upstream minutes once a PR is approved
@@ -853,10 +869,37 @@ jobs:
       ]
     runs-on: ubuntu-22.04
     steps:
+      # Close the window between "approved" and "the approval run registers its
+      # check". A push to an upstream branch resolves the gate to run=false, so
+      # every job above is skipped and the rule below would report a green
+      # `ubuntu CI` on that head SHA. Since branch protection reads the latest
+      # check of that name, the PR would sit on a green required check for the
+      # whole interval between the approval and the new run appearing - long
+      # enough to merge with no CI having ever run. Reporting red instead is the
+      # accurate statement: this SHA has not been validated yet.
+      #
+      # This must FAIL, not be skipped: a skipped check run also counts as
+      # passing for a required status check, so an `if:` on the whole job would
+      # reintroduce the same hole.
+      #
+      # Only upstream pushes are affected. On a fork the gate returns run=true
+      # and the jobs really do run, so a fork's own push CI stays intact.
+      - name: Fail unvalidated upstream push
+        if: github.event_name == 'push' && github.event.repository.fork == false
+        run: |
+          echo "::error title=ubuntu CI::no CI ran for this push; approving the PR triggers it" \
+            && exit 1
+
       - name: Report which dependency failed
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
           echo "$NEEDS" | jq -r 'to_entries[] | "\(.value.result)\t\(.key)"' | sort
+          failed_jobs=$(echo "$NEEDS" | jq -r \
+            'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | .key' \
+            | paste -sd ', ' -)
+          if [ -n "$failed_jobs" ]; then
+            echo "::error title=ubuntu CI::failed or cancelled dependency jobs: $failed_jobs"
+          fi
           echo "$NEEDS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' \
             > /dev/null

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -52,18 +52,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -e
+          set_run() {
+            echo "run=$1" >> "$GITHUB_OUTPUT"
+            echo "::notice title=approval gate::$2"
+          }
           # Push CI belongs to forks only: upstream pushes are covered by the
           # approval-gated review path below.
           if [ "${{ github.event_name }}" = "push" ]; then
-            echo "run=${{ github.event.repository.fork }}" >> "$GITHUB_OUTPUT"
+            if [ "${{ github.event.repository.fork }}" = "true" ]; then
+              set_run true "running CI for fork push"
+            else
+              set_run false "skipping CI for upstream push; approval triggers CI"
+            fi
             exit 0
           fi
           if [ "${{ github.event_name }}" != "pull_request_review" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
+            set_run true "running CI for ${{ github.event_name }} event"
             exit 0
           fi
           if [ "${{ github.event.review.state }}" != "approved" ]; then
-            echo "run=false" >> "$GITHUB_OUTPUT"
+            set_run false "skipping CI because the review is not an approval"
             exit 0
           fi
           # Count APPROVED reviews to run only on the FIRST approval (>1 -> skip).
@@ -75,7 +83,7 @@ jobs:
           n=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --jq '[.[]|select(.state=="APPROVED")]|length')
           if [ "$n" -gt 1 ]; then
-            echo "run=false" >> "$GITHUB_OUTPUT"
+            set_run false "skipping CI because this is not the first approval"
             exit 0
           fi
           # Restore the path filter pull_request had but pull_request_review
@@ -94,9 +102,9 @@ jobs:
           python3 -c 'import yaml' 2>/dev/null \
             || python3 -m pip install --quiet --disable-pip-version-check pyyaml
           if python3 .github/scripts/pr_touches_paths.py \
-              "${filter_arg[@]}" \
-              --changed-files /tmp/changed_files.txt; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
+               "${filter_arg[@]}" \
+               --changed-files /tmp/changed_files.txt; then
+            set_run true "running CI for the first approval of a relevant PR"
           else
-            echo "run=false" >> "$GITHUB_OUTPUT"
+            set_run false "skipping CI because the PR does not touch relevant paths"
           fi


### PR DESCRIPTION
Include CI control files in path filters so approval runs cover workflow changes.

Fail the Ubuntu required check for unvalidated upstream pushes and annotate gate decisions and failed dependencies.