### PR TITLE
ci: rerun CI for rebased PR head SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,8 @@ on:
   # changes are covered by the nightly cron, not per-PR.
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   # midnight UTC on the latest commit on the main branch
   schedule:
     - cron: "0 0 * * *"
@@ -46,18 +48,21 @@ on:
 # finish, so branch and scheduled scans are never dropped.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_review' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_review' || github.event_name == 'pull_request' }}
 
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
 jobs:
   # Gate the upstream approval re-run: only for a PR's first approval AND only
   # when the PR touches the CodeQL pipeline definition (not general source).
   gate:
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -20,6 +20,8 @@ on:
   # (first approval only, enforced by the gate job below).
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -35,7 +37,7 @@ permissions:
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
 jobs:
   # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
@@ -45,6 +47,9 @@ jobs:
   gate:
     name: approval gate
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
@@ -186,13 +191,9 @@ jobs:
   # Single stable check for branch protection. Configure this job, rather than
   # individual lint jobs, as the required status check in the repository ruleset.
   required:
-    # Same pattern as the `required` job in compilation_on_ubuntu.yml: the job
-    # name is the check run name the ruleset matches. On an upstream push this
-    # job is skipped (see the `if:`) and renamed to "coding guidelines (push)":
-    # the skipped run cannot be mistaken for a validation result, and the
-    # required "coding guidelines" name is produced only by the
-    # approval-triggered run - no green check before approval, no false red.
-    name: coding guidelines${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # Same pattern as the `required` job in compilation_on_ubuntu.yml: keep
+    # the canonical required-check name only when gate.run=true.
+    name: coding guidelines${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
     # `always()` is mandatory: on approval-triggered runs this job must run
     # and fail when any dependency failed (a skipped job counts as passing for
     # a required check). Only an upstream push is exempt - the gate already

--- a/.github/workflows/compilation_on_android.yml
+++ b/.github/workflows/compilation_on_android.yml
@@ -36,6 +36,8 @@ on:
   # (first approval only, enforced by the gate job below).
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -48,7 +50,7 @@ concurrency:
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
   # For BUILD. The JIT modes are omitted on purpose: android has no prebuilt
   # LLVM and Fast JIT / Multi-Tier JIT do not support the platform.
   AOT_BUILD_OPTIONS: "           -DWAMR_BUILD_AOT=1 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
@@ -66,6 +68,9 @@ jobs:
   gate:
     name: approval gate
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
@@ -152,18 +157,7 @@ jobs:
   # Single stable check for branch protection - see the same job in
   # compilation_on_ubuntu.yml for why an individual matrix job must not be used.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
-    # the check run name the ruleset matches. On an upstream push this job is
-    # skipped (see the `if:`) and renamed to "android CI (push)": the skipped
-    # run cannot be mistaken for a validation result, and the required "android
-    # CI" name is produced only by the approval-triggered run - no green check
-    # before approval, no false red either.
-    name: android CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
-    # `always()` is mandatory: on approval-triggered runs this job must run
-    # and fail when any dependency failed (a skipped job counts as passing for
-    # a required check). Only an upstream push is exempt - the gate already
-    # resolved to run=false there, every dependency is skipped, and skipping
-    # this job too keeps the whole push run uniformly "did not run".
+    name: android CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
     if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
     needs: [gate, build_iwasm]
     runs-on: ubuntu-22.04

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -41,6 +41,8 @@ on:
   # (first approval only, enforced by the gate job below).
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -53,7 +55,7 @@ concurrency:
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
   # For BUILD
   AOT_BUILD_OPTIONS: "           -DWAMR_BUILD_AOT=1 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
   CLASSIC_INTERP_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=0 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
@@ -74,6 +76,9 @@ jobs:
   gate:
     name: approval gate
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -505,13 +505,9 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
-    # the check run name the ruleset matches. On an upstream push this job is
-    # skipped (see the `if:`) and renamed to "macos CI (push)": the skipped
-    # run cannot be mistaken for a validation result, and the required "macos
-    # CI" name is produced only by the approval-triggered run - no green check
-    # before approval, no false red either.
-    name: macos CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # Same as the `required` job in compilation_on_ubuntu.yml: keep the
+    # canonical required-check name only when gate.run=true.
+    name: macos CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
     # `always()` is mandatory: on approval-triggered runs this job must run
     # and fail when any dependency failed (a skipped job counts as passing for
     # a required check). Only an upstream push is exempt - the gate already

--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -39,6 +39,8 @@ on:
   # (first approval only, enforced by the gate job below).
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -51,7 +53,7 @@ concurrency:
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
   WASI_SDK_PATH: "/opt/wasi-sdk"
   NUTTX_IMAGE: "ghcr.io/apache/nuttx/apache-nuttx-ci-linux@sha256:d9261eacf6c6ebe656c571757751c803e8f04c3ae9b820320a5ea5dd57b7205a"
   # Bump BLOATY_REF to update bloaty. The size-report cache below is keyed on
@@ -69,6 +71,9 @@ jobs:
   gate:
     name: approval gate
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml

--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -242,13 +242,9 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
-    # the check run name the ruleset matches. On an upstream push this job is
-    # skipped (see the `if:`) and renamed to "nuttx CI (push)": the skipped run
-    # cannot be mistaken for a validation result, and the required "nuttx CI"
-    # name is produced only by the approval-triggered run - no green check
-    # before approval, no false red either.
-    name: nuttx CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # Same as the `required` job in compilation_on_ubuntu.yml: keep the
+    # canonical required-check name only when gate.run=true.
+    name: nuttx CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
     # `always()` is mandatory: on approval-triggered runs this job must run
     # and fail when any dependency failed (a skipped job counts as passing for
     # a required check). Only an upstream push is exempt - the gate already

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -41,6 +41,8 @@ on:
   # (first approval only, enforced by the gate job below).
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -53,7 +55,7 @@ concurrency:
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
   # ref types enabled in wamrc by default, so we need to enable it for iwasm in AOT mode
   AOT_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=1 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0 -DWAMR_BUILD_REF_TYPES=1"
   CLASSIC_INTERP_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=0 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
@@ -77,6 +79,9 @@ jobs:
   gate:
     name: approval gate
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -348,13 +348,9 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
-    # the check run name the ruleset matches. On an upstream push this job is
-    # skipped (see the `if:`) and renamed to "sgx CI (push)": the skipped run
-    # cannot be mistaken for a validation result, and the required "sgx CI"
-    # name is produced only by the approval-triggered run - no green check
-    # before approval, no false red either.
-    name: sgx CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # Same as the `required` job in compilation_on_ubuntu.yml: keep the
+    # canonical required-check name only when gate.run=true.
+    name: sgx CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
     # `always()` is mandatory: on approval-triggered runs this job must run
     # and fail when any dependency failed (a skipped job counts as passing for
     # a required check). Only an upstream push is exempt - the gate already

--- a/.github/workflows/compilation_on_ubuntu.yml
+++ b/.github/workflows/compilation_on_ubuntu.yml
@@ -52,6 +52,8 @@ on:
   # (first approval only, enforced by the gate job below).
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -64,7 +66,7 @@ concurrency:
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
   # For BUILD
   AOT_BUILD_OPTIONS: "           -DWAMR_BUILD_AOT=1 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
   CLASSIC_INTERP_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=0 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
@@ -97,6 +99,9 @@ jobs:
   gate:
     name: approval gate
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
@@ -853,12 +858,10 @@ jobs:
   # every job below is skipped, and that is the normal path.
   required:
     # `name:` doubles as the check run name, which is what the ruleset's
-    # required_status_checks matches. On an upstream push this job is skipped
-    # (see the `if:`) and renamed to "ubuntu CI (push)": the skipped run
-    # cannot be mistaken for a validation result, and the required "ubuntu CI"
-    # name is produced only by the approval-triggered run - no green check
-    # before approval, no false red either.
-    name: ubuntu CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # required_status_checks matches. Keep the canonical "ubuntu CI" name only
+    # when gate.run=true (approval-triggered CI and post-rebase CI). Every
+    # other case gets a non-required alias.
+    name: ubuntu CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
     # `always()` is mandatory: on approval-triggered runs this job must run
     # and fail when any dependency failed (a skipped job counts as passing for
     # a required check). Only an upstream push is exempt - the gate already

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -40,13 +40,15 @@ on:
   # (first approval only, enforced by the gate job below).
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   # allow to be triggered manually
   workflow_dispatch:
 
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
   # For Spec Test
   DEFAULT_TEST_OPTIONS: "-s spec -b"
   MULTI_MODULES_TEST_OPTIONS: "-s spec -b -M"
@@ -73,6 +75,9 @@ jobs:
   gate:
     name: approval gate
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -229,13 +229,9 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
-    # the check run name the ruleset matches. On an upstream push this job is
-    # skipped (see the `if:`) and renamed to "windows CI (push)": the skipped
-    # run cannot be mistaken for a validation result, and the required "windows
-    # CI" name is produced only by the approval-triggered run - no green check
-    # before approval, no false red either.
-    name: windows CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # Same as the `required` job in compilation_on_ubuntu.yml: keep the
+    # canonical required-check name only when gate.run=true.
+    name: windows CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
     # `always()` is mandatory: on approval-triggered runs this job must run
     # and fail when any dependency failed (a skipped job counts as passing for
     # a required check). Only an upstream push is exempt - the gate already

--- a/.github/workflows/compilation_on_zephyr.yml
+++ b/.github/workflows/compilation_on_zephyr.yml
@@ -174,13 +174,9 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
-    # the check run name the ruleset matches. On an upstream push this job is
-    # skipped (see the `if:`) and renamed to "zephyr CI (push)": the skipped
-    # run cannot be mistaken for a validation result, and the required "zephyr
-    # CI" name is produced only by the approval-triggered run - no green check
-    # before approval, no false red either.
-    name: zephyr CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # Same as the `required` job in compilation_on_ubuntu.yml: keep the
+    # canonical required-check name only when gate.run=true.
+    name: zephyr CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
     # `always()` is mandatory: on approval-triggered runs this job must run
     # and fail when any dependency failed (a skipped job counts as passing for
     # a required check). Only an upstream push is exempt - the gate already

--- a/.github/workflows/compilation_on_zephyr.yml
+++ b/.github/workflows/compilation_on_zephyr.yml
@@ -40,6 +40,8 @@ on:
   # (first approval only, enforced by the gate job below).
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -52,7 +54,7 @@ concurrency:
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
   # FOR SETUP
   ZEPHYR_SDK_VERSION: "0.16.9"
   ZEPHYR_VERSION: "v3.7.0"
@@ -69,6 +71,9 @@ jobs:
   gate:
     name: approval gate
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -5,8 +5,12 @@
 # `uses:` and gate their real jobs on `needs.gate.outputs.run`. Per event:
 #   - push: runs only on a fork, so upstream never spends minutes on a plain
 #     push; contributors still get CI on their own fork's branches.
-#   - pull_request_review (submitted) and pull_request (synchronize): for a PR
-#     that touches relevant paths, run once per head SHA after the PR is
+#   - pull_request_review (submitted): only the first approval of a PR runs CI
+#     for the head SHA (repo policy allows exactly one approval). It is the
+#     authoritative CI trigger and is never deduplicated away: a prior
+#     synchronize run that resolved run=false (every job skipped) must not
+#     block it, or heavy CI would never run on the approved SHA.
+#   - pull_request (synchronize): run once per head SHA after the PR is
 #     approved. A synchronize event on an unapproved relevant PR reports an
 #     "awaiting approval" status so required checks are not faked green.
 #   - anything else (e.g. workflow_dispatch, schedule): always runs.
@@ -90,9 +94,23 @@ jobs:
             exit 0
           fi
 
-          # Repository policy requires exactly one approval. Therefore an
-          # `approved` pull_request_review event can proceed directly; only
-          # synchronize events need an explicit reviewDecision check.
+          # Repository policy requires exactly one approval: count APPROVED
+          # reviews so only the first approval triggers CI, and a second
+          # approval on the same head SHA does not re-run the pipeline. This
+          # relies on the branch rule "Dismiss stale pull request approvals
+          # when new commits are pushed": dismissed reviews stop counting here.
+          if [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            n=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+                --jq '[.[]|select(.state=="APPROVED")]|length')
+            if [ "$n" -gt 1 ]; then
+              set_run false "skipping CI because this is not the first approval"
+              exit 0
+            fi
+          fi
+
+          # An `approved` pull_request_review event can therefore proceed
+          # directly; only synchronize events need an explicit reviewDecision
+          # check.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             decision=$(gh api graphql \
                 -f query="query(\$owner:String!, \$repo:String!, \$number:Int!) { repository(owner:\$owner, name:\$repo) { pullRequest(number:\$number) { reviewDecision } } }" \
@@ -133,20 +151,27 @@ jobs:
             exit 0
           fi
 
-          # Run CI at most once per head SHA. A run already queued or in
-          # progress (conclusion == null) counts too.
+          # Run CI at most once per head SHA - synchronize events only. An
+          # `approved` pull_request_review event is the authoritative CI
+          # trigger (the first-approval guard above enforces the one-approval
+          # policy), so it must never be short-circuited by a prior run that
+          # resolved run=false (every job skipped) yet still concluded
+          # "success" - otherwise heavy CI would never run on an approved SHA.
+          # A run already queued or in progress (conclusion == null) counts too.
           # SC2016: `$wf` and `$self` are jq variables.
           # shellcheck disable=SC2016
-          prior=$(gh api \
-              "repos/${{ github.repository }}/actions/runs?head_sha=${{ github.event.pull_request.head.sha }}&per_page=100" \
-            | jq --arg wf "${{ github.workflow }}" --arg self "${{ github.run_id }}" \
-                  '[ .workflow_runs[]
-                     | select(.name == $wf and (.id | tostring) != $self)
-                     | select(.event == "pull_request" or .event == "pull_request_review")
-                     | select(.conclusion == null or .conclusion == "success")
-                   ] | length')
-          if [ "$prior" -gt 0 ]; then
-            set_run false "skipping CI because ${{ github.event.pull_request.head.sha }} already has a run"
-            exit 0
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            prior=$(gh api \
+                "repos/${{ github.repository }}/actions/runs?head_sha=${{ github.event.pull_request.head.sha }}&per_page=100" \
+              | jq --arg wf "${{ github.workflow }}" --arg self "${{ github.run_id }}" \
+                    '[ .workflow_runs[]
+                       | select(.name == $wf and (.id | tostring) != $self)
+                       | select(.event == "pull_request" or .event == "pull_request_review")
+                       | select(.conclusion == null or .conclusion == "success")
+                     ] | length')
+            if [ "$prior" -gt 0 ]; then
+              set_run false "skipping CI because ${{ github.event.pull_request.head.sha }} already has a run"
+              exit 0
+            fi
           fi
           set_run true "running CI for approved relevant PR SHA ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -5,9 +5,10 @@
 # `uses:` and gate their real jobs on `needs.gate.outputs.run`. Per event:
 #   - push: runs only on a fork, so upstream never spends minutes on a plain
 #     push; contributors still get CI on their own fork's branches.
-#   - pull_request_review: runs only for the FIRST approval of a PR and only
-#     when the PR touches the caller workflow's push.paths (the path filter
-#     pull_request_review lacks, re-applied via pr_touches_paths.py).
+#   - pull_request_review (submitted) and pull_request (synchronize): for a PR
+#     that touches relevant paths, run once per head SHA after the PR is
+#     approved. A synchronize event on an unapproved relevant PR reports an
+#     "awaiting approval" status so required checks are not faked green.
 #   - anything else (e.g. workflow_dispatch, schedule): always runs.
 name: gate
 
@@ -29,6 +30,8 @@ on:
         value: ${{ jobs.gate.outputs.run }}
 
 permissions:
+  # `actions: read` lets the dedup query below list this workflow's own runs.
+  actions: read
   contents: read
   pull-requests: read
 
@@ -51,11 +54,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -e
+          # pipefail matters: the dedup query below pipes `gh api` into jq, and
+          # a silent API failure there must not read as "no prior run".
+          set -eo pipefail
           set_run() {
-            echo "run=$1" >> "$GITHUB_OUTPUT"
-            echo "::notice title=approval gate::$2"
+            local run="$1"
+            local message="$2"
+            echo "run=$run" >> "$GITHUB_OUTPUT"
+            echo "::notice title=approval gate::$message"
           }
+
           # Push CI belongs to forks only: upstream pushes are covered by the
           # approval-gated review path below.
           if [ "${{ github.event_name }}" = "push" ]; then
@@ -66,26 +74,38 @@ jobs:
             fi
             exit 0
           fi
-          if [ "${{ github.event_name }}" != "pull_request_review" ]; then
+
+          # Only PR approval pathways need the extra approval/path/dedup logic.
+          # For all other events (workflow_dispatch, schedule, etc.), run
+          # directly and let downstream jobs decide as usual.
+          if [ "${{ github.event_name }}" != "pull_request_review" ] \
+             && [ "${{ github.event_name }}" != "pull_request" ]; then
             set_run true "running CI for ${{ github.event_name }} event"
             exit 0
           fi
-          if [ "${{ github.event.review.state }}" != "approved" ]; then
+
+          if [ "${{ github.event_name }}" = "pull_request_review" ] \
+             && [ "${{ github.event.review.state }}" != "approved" ]; then
             set_run false "skipping CI because the review is not an approval"
             exit 0
           fi
-          # Count APPROVED reviews to run only on the FIRST approval (>1 -> skip).
-          # This relies on the branch rule "Dismiss stale pull request approvals
-          # when new commits are pushed": a new push must flip prior approvals to
-          # DISMISSED so they stop counting here. Without that setting a
-          # re-approval accumulates a second APPROVED and is silently skipped -
-          # keep the rule enabled in repo settings.
-          n=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
-              --jq '[.[]|select(.state=="APPROVED")]|length')
-          if [ "$n" -gt 1 ]; then
-            set_run false "skipping CI because this is not the first approval"
-            exit 0
+
+          # Repository policy requires exactly one approval. Therefore an
+          # `approved` pull_request_review event can proceed directly; only
+          # synchronize events need an explicit reviewDecision check.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            decision=$(gh api graphql \
+                -f query="query(\$owner:String!, \$repo:String!, \$number:Int!) { repository(owner:\$owner, name:\$repo) { pullRequest(number:\$number) { reviewDecision } } }" \
+                -F owner="${{ github.repository_owner }}" \
+                -F repo="${{ github.event.repository.name }}" \
+                -F number="${{ github.event.pull_request.number }}" \
+                --jq '.data.repository.pullRequest.reviewDecision // "REVIEW_REQUIRED"')
+            if [ "$decision" != "APPROVED" ]; then
+              set_run false "waiting for approval of this synchronized SHA"
+              exit 0
+            fi
           fi
+
           # Restore the path filter pull_request had but pull_request_review
           # lacks: only run when the PR actually touches relevant files.
           gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
@@ -104,7 +124,29 @@ jobs:
           if python3 .github/scripts/pr_touches_paths.py \
                "${filter_arg[@]}" \
                --changed-files /tmp/changed_files.txt; then
-            set_run true "running CI for the first approval of a relevant PR"
+            touches_paths=true
           else
-            set_run false "skipping CI because the PR does not touch relevant paths"
+            touches_paths=false
           fi
+          if [ "$touches_paths" != "true" ]; then
+            set_run false "skipping CI because the PR does not touch relevant paths"
+            exit 0
+          fi
+
+          # Run CI at most once per head SHA. A run already queued or in
+          # progress (conclusion == null) counts too.
+          # SC2016: `$wf` and `$self` are jq variables.
+          # shellcheck disable=SC2016
+          prior=$(gh api \
+              "repos/${{ github.repository }}/actions/runs?head_sha=${{ github.event.pull_request.head.sha }}&per_page=100" \
+            | jq --arg wf "${{ github.workflow }}" --arg self "${{ github.run_id }}" \
+                  '[ .workflow_runs[]
+                     | select(.name == $wf and (.id | tostring) != $self)
+                     | select(.event == "pull_request" or .event == "pull_request_review")
+                     | select(.conclusion == null or .conclusion == "success")
+                   ] | length')
+          if [ "$prior" -gt 0 ]; then
+            set_run false "skipping CI because ${{ github.event.pull_request.head.sha }} already has a run"
+            exit 0
+          fi
+          set_run true "running CI for approved relevant PR SHA ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -27,6 +27,8 @@ on:
   # changes are covered by the nightly cron, not per-PR.
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
 
   # midnight UTC
   schedule:
@@ -43,7 +45,7 @@ concurrency:
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
   # For BUILD
   AOT_BUILD_OPTIONS: "           -DWAMR_BUILD_AOT=1 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
   CLASSIC_INTERP_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=0 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
@@ -69,6 +71,9 @@ jobs:
   # when the PR touches the nightly pipeline definition (not general source).
   gate:
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml

--- a/.github/workflows/spec_test_on_nuttx.yml
+++ b/.github/workflows/spec_test_on_nuttx.yml
@@ -30,6 +30,8 @@ on:
   # (first approval only, enforced by the gate job below).
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   schedule:
     - cron:  '0 0 * * *'
 
@@ -41,7 +43,7 @@ on:
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
   LLVM_CACHE_SUFFIX: "build-llvm_libraries_ex"
   WASI_SDK_PATH: "/opt/wasi-sdk"
 
@@ -55,6 +57,9 @@ jobs:
   # descendant, even ones that broke the chain with their own `if`.
   gate:
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml

--- a/.github/workflows/wamr_wasi_extensions.yml
+++ b/.github/workflows/wamr_wasi_extensions.yml
@@ -26,6 +26,8 @@ on:
   # (first approval only, enforced by the gate job below).
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize]
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -38,7 +40,7 @@ concurrency:
 env:
   # Merge ref to check out on approval-gated review events; empty elsewhere
   # so checkout falls back to the event's default ref.
-  PR_REF: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+  PR_REF: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
 jobs:
   # Gate upstream minutes: always runs (a few-second no-op) and outputs `run`,
@@ -47,6 +49,9 @@ jobs:
   # descendant, even ones that broke the chain with their own `if`.
   gate:
     permissions:
+      # `actions: read`: the gate dedups per head SHA by listing this
+      # workflow's own runs.
+      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml


### PR DESCRIPTION
GitHub's "dismiss stale pull request approvals" rule decides by diff, so a rebase or the "Update branch" button can keep approval while rewriting the head SHA. In that case, required checks must come from a CI run on the new SHA: either dismiss approval and require re-approval, or trigger CI again on the rewritten SHA so PR authors can fix failures on the latest head.

This commit implements the second path: after rebase/synchronize updates a PR, the workflow can trigger CI for the new head SHA and publish fresh required-check status from that run.
    