### PR TITLE
ci: extend approval-gated required checks to the remaining compilation workflows

### DIFF
--- a/.github/workflows/compilation_on_android.yml
+++ b/.github/workflows/compilation_on_android.yml
@@ -81,7 +81,7 @@ jobs:
   # See the same document, section 3.5.
   build_iwasm:
     needs: gate
-    if: ${{ !cancelled() && (github.event_name != 'pull_request_review' || needs.gate.outputs.run == 'true') }}
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -157,10 +157,37 @@ jobs:
     needs: [gate, build_iwasm]
     runs-on: ubuntu-22.04
     steps:
+      # Close the window between "approved" and "the approval run registers its
+      # check". A push to an upstream branch resolves the gate to run=false, so
+      # every job above is skipped and the rule below would report a green
+      # `android CI` on that head SHA. Since branch protection reads the latest
+      # check of that name, the PR would sit on a green required check for the
+      # whole interval between the approval and the new run appearing - long
+      # enough to merge with no CI having ever run. Reporting red instead is the
+      # accurate statement: this SHA has not been validated yet.
+      #
+      # This must FAIL, not be skipped: a skipped check run also counts as
+      # passing for a required status check, so an `if:` on the whole job would
+      # reintroduce the same hole.
+      #
+      # Only upstream pushes are affected. On a fork the gate returns run=true
+      # and the jobs really do run, so a fork's own push CI stays intact.
+      - name: Fail unvalidated upstream push
+        if: github.event_name == 'push' && github.event.repository.fork == false
+        run: |
+          echo "::error title=android CI::no CI ran for this push; approving the PR triggers it" \
+            && exit 1
+
       - name: Report which dependency failed
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
           echo "$NEEDS" | jq -r 'to_entries[] | "\(.value.result)\t\(.key)"' | sort
+          failed_jobs=$(echo "$NEEDS" | jq -r \
+            'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | .key' \
+            | paste -sd ', ' -)
+          if [ -n "$failed_jobs" ]; then
+            echo "::error title=android CI::failed or cancelled dependency jobs: $failed_jobs"
+          fi
           echo "$NEEDS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' \
             > /dev/null

--- a/.github/workflows/compilation_on_android.yml
+++ b/.github/workflows/compilation_on_android.yml
@@ -152,32 +152,22 @@ jobs:
   # Single stable check for branch protection - see the same job in
   # compilation_on_ubuntu.yml for why an individual matrix job must not be used.
   required:
-    name: android CI
-    if: always()
+    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
+    # the check run name the ruleset matches. On an upstream push this job is
+    # skipped (see the `if:`) and renamed to "android CI (push)": the skipped
+    # run cannot be mistaken for a validation result, and the required "android
+    # CI" name is produced only by the approval-triggered run - no green check
+    # before approval, no false red either.
+    name: android CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # `always()` is mandatory: on approval-triggered runs this job must run
+    # and fail when any dependency failed (a skipped job counts as passing for
+    # a required check). Only an upstream push is exempt - the gate already
+    # resolved to run=false there, every dependency is skipped, and skipping
+    # this job too keeps the whole push run uniformly "did not run".
+    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
     needs: [gate, build_iwasm]
     runs-on: ubuntu-22.04
     steps:
-      # Close the window between "approved" and "the approval run registers its
-      # check". A push to an upstream branch resolves the gate to run=false, so
-      # every job above is skipped and the rule below would report a green
-      # `android CI` on that head SHA. Since branch protection reads the latest
-      # check of that name, the PR would sit on a green required check for the
-      # whole interval between the approval and the new run appearing - long
-      # enough to merge with no CI having ever run. Reporting red instead is the
-      # accurate statement: this SHA has not been validated yet.
-      #
-      # This must FAIL, not be skipped: a skipped check run also counts as
-      # passing for a required status check, so an `if:` on the whole job would
-      # reintroduce the same hole.
-      #
-      # Only upstream pushes are affected. On a fork the gate returns run=true
-      # and the jobs really do run, so a fork's own push CI stays intact.
-      - name: Fail unvalidated upstream push
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        run: |
-          echo "::error title=android CI::no CI ran for this push; approving the PR triggers it" \
-            && exit 1
-
       - name: Report which dependency failed
         env:
           NEEDS: ${{ toJSON(needs) }}

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -500,8 +500,19 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    name: macos CI
-    if: always()
+    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
+    # the check run name the ruleset matches. On an upstream push this job is
+    # skipped (see the `if:`) and renamed to "macos CI (push)": the skipped
+    # run cannot be mistaken for a validation result, and the required "macos
+    # CI" name is produced only by the approval-triggered run - no green check
+    # before approval, no false red either.
+    name: macos CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # `always()` is mandatory: on approval-triggered runs this job must run
+    # and fail when any dependency failed (a skipped job counts as passing for
+    # a required check). Only an upstream push is exempt - the gate already
+    # resolved to run=false there, every dependency is skipped, and skipping
+    # this job too keeps the whole push run uniformly "did not run".
+    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
     needs:
       [
         gate,
@@ -514,27 +525,6 @@ jobs:
       ]
     runs-on: ubuntu-22.04
     steps:
-      # Close the window between "approved" and "the approval run registers its
-      # check". A push to an upstream branch resolves the gate to run=false, so
-      # every job above is skipped and the rule below would report a green
-      # `macos CI` on that head SHA. Since branch protection reads the latest
-      # check of that name, the PR would sit on a green required check for the
-      # whole interval between the approval and the new run appearing - long
-      # enough to merge with no CI having ever run. Reporting red instead is the
-      # accurate statement: this SHA has not been validated yet.
-      #
-      # This must FAIL, not be skipped: a skipped check run also counts as
-      # passing for a required status check, so an `if:` on the whole job would
-      # reintroduce the same hole.
-      #
-      # Only upstream pushes are affected. On a fork the gate returns run=true
-      # and the jobs really do run, so a fork's own push CI stays intact.
-      - name: Fail unvalidated upstream push
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        run: |
-          echo "::error title=macos CI::no CI ran for this push; approving the PR triggers it" \
-            && exit 1
-
       - name: Report which dependency failed
         env:
           NEEDS: ${{ toJSON(needs) }}

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -17,9 +17,18 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
+    # This list is also what the approval gate re-applies on
+    # pull_request_review (see gate.yml). Because `required` below treats a
+    # skipped job as success, anything missing here makes `macos CI` go green
+    # without building - so every input this workflow's result depends on must
+    # be listed, including the reusable workflows and composite actions it
+    # calls and the gate machinery that decides whether it runs at all.
     paths:
+      - ".github/actions/**"
+      - ".github/scripts/**"
       - ".github/workflows/build_llvm_libraries.yml"
       - ".github/workflows/compilation_on_macos.yml"
+      - ".github/workflows/gate.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -63,6 +72,7 @@ jobs:
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
+    name: approval gate
     permissions:
       contents: read
       pull-requests: read
@@ -237,7 +247,6 @@ jobs:
   build_samples_wasm_c_api:
     needs:
       [
-        build_iwasm,
         build_llvm_libraries_on_intel_macos,
         build_llvm_libraries_on_arm_macos,
         build_wamrc,
@@ -317,7 +326,7 @@ jobs:
         working-directory: samples/printversion
 
   build_samples_others:
-    needs: [build_iwasm, build_wamrc, build_llvm_libraries_on_intel_macos, build_llvm_libraries_on_arm_macos]
+    needs: [build_wamrc, build_llvm_libraries_on_intel_macos, build_llvm_libraries_on_arm_macos]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -477,3 +486,65 @@ jobs:
           cmake --build . --config Release --parallel 4
           cd ../../../../tests/standalone/test-aot-x18-reserve
           ./run.sh --aot
+
+  # Single stable check for branch protection. Set THIS as the required status
+  # check, never an individual job: matrix job names are built from the matrix
+  # dimensions, so every matrix refactor renames all of them and silently
+  # invalidates whatever was configured under Settings -> Branches.
+  #
+  # `if: always()` is mandatory. Without it this job is skipped whenever an
+  # upstream job fails, and a skipped job counts as passing for a required
+  # check - it would be a gate that is green forever.
+  #
+  # `skipped` must count as success: when the gate resolves to run=false (the
+  # PR does not touch this workflow's paths, or it is not the first approval)
+  # every job below is skipped, and that is the normal path.
+  required:
+    name: macos CI
+    if: always()
+    needs:
+      [
+        gate,
+        build_llvm_libraries_on_intel_macos,
+        build_llvm_libraries_on_arm_macos,
+        build_wamrc,
+        build_iwasm,
+        build_samples_wasm_c_api,
+        build_samples_others,
+      ]
+    runs-on: ubuntu-22.04
+    steps:
+      # Close the window between "approved" and "the approval run registers its
+      # check". A push to an upstream branch resolves the gate to run=false, so
+      # every job above is skipped and the rule below would report a green
+      # `macos CI` on that head SHA. Since branch protection reads the latest
+      # check of that name, the PR would sit on a green required check for the
+      # whole interval between the approval and the new run appearing - long
+      # enough to merge with no CI having ever run. Reporting red instead is the
+      # accurate statement: this SHA has not been validated yet.
+      #
+      # This must FAIL, not be skipped: a skipped check run also counts as
+      # passing for a required status check, so an `if:` on the whole job would
+      # reintroduce the same hole.
+      #
+      # Only upstream pushes are affected. On a fork the gate returns run=true
+      # and the jobs really do run, so a fork's own push CI stays intact.
+      - name: Fail unvalidated upstream push
+        if: github.event_name == 'push' && github.event.repository.fork == false
+        run: |
+          echo "::error title=macos CI::no CI ran for this push; approving the PR triggers it" \
+            && exit 1
+
+      - name: Report which dependency failed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.value.result)\t\(.key)"' | sort
+          failed_jobs=$(echo "$NEEDS" | jq -r \
+            'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | .key' \
+            | paste -sd ', ' -)
+          if [ -n "$failed_jobs" ]; then
+            echo "::error title=macos CI::failed or cancelled dependency jobs: $failed_jobs"
+          fi
+          echo "$NEEDS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' \
+            > /dev/null

--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -17,8 +17,16 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
+    # This list is also what the approval gate re-applies on
+    # pull_request_review (see gate.yml). Because `required` below treats a
+    # skipped job as success, anything missing here makes `nuttx CI` go green
+    # without building - so every input this workflow's result depends on must
+    # be listed, including the reusable workflows and composite actions it
+    # calls and the gate machinery that decides whether it runs at all.
     paths:
+      - ".github/scripts/**"
       - ".github/workflows/compilation_on_nuttx.yml"
+      - ".github/workflows/gate.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -59,6 +67,7 @@ jobs:
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
+    name: approval gate
     permissions:
       contents: read
       pull-requests: read
@@ -214,3 +223,56 @@ jobs:
               echo "libc-wasi size (if enabled):"
               bloaty-bin/bloaty -d compileunits --source-filter libc-wasi nuttx/nuttx
             '
+
+  # Single stable check for branch protection. Set THIS as the required status
+  # check, never an individual job: matrix job names are built from the matrix
+  # dimensions, so every matrix refactor renames all of them and silently
+  # invalidates whatever was configured under Settings -> Branches.
+  #
+  # `if: always()` is mandatory. Without it this job is skipped whenever an
+  # upstream job fails, and a skipped job counts as passing for a required
+  # check - it would be a gate that is green forever.
+  #
+  # `skipped` must count as success: when the gate resolves to run=false (the
+  # PR does not touch this workflow's paths, or it is not the first approval)
+  # every job below is skipped, and that is the normal path.
+  required:
+    name: nuttx CI
+    if: always()
+    needs: [gate, build_bloaty, build_iwasm_on_nuttx]
+    runs-on: ubuntu-22.04
+    steps:
+      # Close the window between "approved" and "the approval run registers its
+      # check". A push to an upstream branch resolves the gate to run=false, so
+      # every job above is skipped and the rule below would report a green
+      # `nuttx CI` on that head SHA. Since branch protection reads the latest
+      # check of that name, the PR would sit on a green required check for the
+      # whole interval between the approval and the new run appearing - long
+      # enough to merge with no CI having ever run. Reporting red instead is the
+      # accurate statement: this SHA has not been validated yet.
+      #
+      # This must FAIL, not be skipped: a skipped check run also counts as
+      # passing for a required status check, so an `if:` on the whole job would
+      # reintroduce the same hole.
+      #
+      # Only upstream pushes are affected. On a fork the gate returns run=true
+      # and the jobs really do run, so a fork's own push CI stays intact.
+      - name: Fail unvalidated upstream push
+        if: github.event_name == 'push' && github.event.repository.fork == false
+        run: |
+          echo "::error title=nuttx CI::no CI ran for this push; approving the PR triggers it" \
+            && exit 1
+
+      - name: Report which dependency failed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.value.result)\t\(.key)"' | sort
+          failed_jobs=$(echo "$NEEDS" | jq -r \
+            'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | .key' \
+            | paste -sd ', ' -)
+          if [ -n "$failed_jobs" ]; then
+            echo "::error title=nuttx CI::failed or cancelled dependency jobs: $failed_jobs"
+          fi
+          echo "$NEEDS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' \
+            > /dev/null

--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -237,32 +237,22 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    name: nuttx CI
-    if: always()
+    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
+    # the check run name the ruleset matches. On an upstream push this job is
+    # skipped (see the `if:`) and renamed to "nuttx CI (push)": the skipped run
+    # cannot be mistaken for a validation result, and the required "nuttx CI"
+    # name is produced only by the approval-triggered run - no green check
+    # before approval, no false red either.
+    name: nuttx CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # `always()` is mandatory: on approval-triggered runs this job must run
+    # and fail when any dependency failed (a skipped job counts as passing for
+    # a required check). Only an upstream push is exempt - the gate already
+    # resolved to run=false there, every dependency is skipped, and skipping
+    # this job too keeps the whole push run uniformly "did not run".
+    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
     needs: [gate, build_bloaty, build_iwasm_on_nuttx]
     runs-on: ubuntu-22.04
     steps:
-      # Close the window between "approved" and "the approval run registers its
-      # check". A push to an upstream branch resolves the gate to run=false, so
-      # every job above is skipped and the rule below would report a green
-      # `nuttx CI` on that head SHA. Since branch protection reads the latest
-      # check of that name, the PR would sit on a green required check for the
-      # whole interval between the approval and the new run appearing - long
-      # enough to merge with no CI having ever run. Reporting red instead is the
-      # accurate statement: this SHA has not been validated yet.
-      #
-      # This must FAIL, not be skipped: a skipped check run also counts as
-      # passing for a required status check, so an `if:` on the whole job would
-      # reintroduce the same hole.
-      #
-      # Only upstream pushes are affected. On a fork the gate returns run=true
-      # and the jobs really do run, so a fork's own push CI stays intact.
-      - name: Fail unvalidated upstream push
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        run: |
-          echo "::error title=nuttx CI::no CI ran for this push; approving the PR triggers it" \
-            && exit 1
-
       - name: Report which dependency failed
         env:
           NEEDS: ${{ toJSON(needs) }}

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -343,32 +343,22 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    name: sgx CI
-    if: always()
+    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
+    # the check run name the ruleset matches. On an upstream push this job is
+    # skipped (see the `if:`) and renamed to "sgx CI (push)": the skipped run
+    # cannot be mistaken for a validation result, and the required "sgx CI"
+    # name is produced only by the approval-triggered run - no green check
+    # before approval, no false red either.
+    name: sgx CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # `always()` is mandatory: on approval-triggered runs this job must run
+    # and fail when any dependency failed (a skipped job counts as passing for
+    # a required check). Only an upstream push is exempt - the gate already
+    # resolved to run=false there, every dependency is skipped, and skipping
+    # this job too keeps the whole push run uniformly "did not run".
+    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
     needs: [gate, build_llvm_libraries, build_iwasm, run_samples_file, spec_test_default]
     runs-on: ubuntu-22.04
     steps:
-      # Close the window between "approved" and "the approval run registers its
-      # check". A push to an upstream branch resolves the gate to run=false, so
-      # every job above is skipped and the rule below would report a green
-      # `sgx CI` on that head SHA. Since branch protection reads the latest
-      # check of that name, the PR would sit on a green required check for the
-      # whole interval between the approval and the new run appearing - long
-      # enough to merge with no CI having ever run. Reporting red instead is the
-      # accurate statement: this SHA has not been validated yet.
-      #
-      # This must FAIL, not be skipped: a skipped check run also counts as
-      # passing for a required status check, so an `if:` on the whole job would
-      # reintroduce the same hole.
-      #
-      # Only upstream pushes are affected. On a fork the gate returns run=true
-      # and the jobs really do run, so a fork's own push CI stays intact.
-      - name: Fail unvalidated upstream push
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        run: |
-          echo "::error title=sgx CI::no CI ran for this push; approving the PR triggers it" \
-            && exit 1
-
       - name: Report which dependency failed
         env:
           NEEDS: ${{ toJSON(needs) }}

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -17,9 +17,18 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
+    # This list is also what the approval gate re-applies on
+    # pull_request_review (see gate.yml). Because `required` below treats a
+    # skipped job as success, anything missing here makes `sgx CI` go green
+    # without building - so every input this workflow's result depends on must
+    # be listed, including the reusable workflows and composite actions it
+    # calls and the gate machinery that decides whether it runs at all.
     paths:
+      - ".github/actions/**"
+      - ".github/scripts/**"
       - ".github/workflows/build_llvm_libraries.yml"
       - ".github/workflows/compilation_on_sgx.yml"
+      - ".github/workflows/gate.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -66,6 +75,7 @@ jobs:
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
+    name: approval gate
     permissions:
       contents: read
       pull-requests: read
@@ -154,7 +164,7 @@ jobs:
         working-directory: product-mini/platforms/${{ matrix.platform }}
 
   run_samples_file:
-    needs: [build_iwasm, build_llvm_libraries]
+    needs: [build_llvm_libraries]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -248,7 +258,7 @@ jobs:
         working-directory: product-mini/platforms/${{ matrix.platform }}/enclave-sample
 
   spec_test_default:
-    needs: [build_iwasm, build_llvm_libraries]
+    needs: [build_llvm_libraries]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -319,3 +329,56 @@ jobs:
           source /opt/intel/sgxsdk/environment
           ./test_wamr.sh ${{ matrix.test_option }} -t ${{ matrix.running_mode }}
         working-directory: ./tests/wamr-test-suites
+
+  # Single stable check for branch protection. Set THIS as the required status
+  # check, never an individual job: matrix job names are built from the matrix
+  # dimensions, so every matrix refactor renames all of them and silently
+  # invalidates whatever was configured under Settings -> Branches.
+  #
+  # `if: always()` is mandatory. Without it this job is skipped whenever an
+  # upstream job fails, and a skipped job counts as passing for a required
+  # check - it would be a gate that is green forever.
+  #
+  # `skipped` must count as success: when the gate resolves to run=false (the
+  # PR does not touch this workflow's paths, or it is not the first approval)
+  # every job below is skipped, and that is the normal path.
+  required:
+    name: sgx CI
+    if: always()
+    needs: [gate, build_llvm_libraries, build_iwasm, run_samples_file, spec_test_default]
+    runs-on: ubuntu-22.04
+    steps:
+      # Close the window between "approved" and "the approval run registers its
+      # check". A push to an upstream branch resolves the gate to run=false, so
+      # every job above is skipped and the rule below would report a green
+      # `sgx CI` on that head SHA. Since branch protection reads the latest
+      # check of that name, the PR would sit on a green required check for the
+      # whole interval between the approval and the new run appearing - long
+      # enough to merge with no CI having ever run. Reporting red instead is the
+      # accurate statement: this SHA has not been validated yet.
+      #
+      # This must FAIL, not be skipped: a skipped check run also counts as
+      # passing for a required status check, so an `if:` on the whole job would
+      # reintroduce the same hole.
+      #
+      # Only upstream pushes are affected. On a fork the gate returns run=true
+      # and the jobs really do run, so a fork's own push CI stays intact.
+      - name: Fail unvalidated upstream push
+        if: github.event_name == 'push' && github.event.repository.fork == false
+        run: |
+          echo "::error title=sgx CI::no CI ran for this push; approving the PR triggers it" \
+            && exit 1
+
+      - name: Report which dependency failed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.value.result)\t\(.key)"' | sort
+          failed_jobs=$(echo "$NEEDS" | jq -r \
+            'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | .key' \
+            | paste -sd ', ' -)
+          if [ -n "$failed_jobs" ]; then
+            echo "::error title=sgx CI::failed or cancelled dependency jobs: $failed_jobs"
+          fi
+          echo "$NEEDS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' \
+            > /dev/null

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -224,8 +224,19 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    name: windows CI
-    if: always()
+    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
+    # the check run name the ruleset matches. On an upstream push this job is
+    # skipped (see the `if:`) and renamed to "windows CI (push)": the skipped
+    # run cannot be mistaken for a validation result, and the required "windows
+    # CI" name is produced only by the approval-triggered run - no green check
+    # before approval, no false red either.
+    name: windows CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # `always()` is mandatory: on approval-triggered runs this job must run
+    # and fail when any dependency failed (a skipped job counts as passing for
+    # a required check). Only an upstream push is exempt - the gate already
+    # resolved to run=false there, every dependency is skipped, and skipping
+    # this job too keeps the whole push run uniformly "did not run".
+    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
     needs:
       [
         gate,
@@ -236,27 +247,6 @@ jobs:
       ]
     runs-on: ubuntu-22.04
     steps:
-      # Close the window between "approved" and "the approval run registers its
-      # check". A push to an upstream branch resolves the gate to run=false, so
-      # every job above is skipped and the rule below would report a green
-      # `windows CI` on that head SHA. Since branch protection reads the latest
-      # check of that name, the PR would sit on a green required check for the
-      # whole interval between the approval and the new run appearing - long
-      # enough to merge with no CI having ever run. Reporting red instead is the
-      # accurate statement: this SHA has not been validated yet.
-      #
-      # This must FAIL, not be skipped: a skipped check run also counts as
-      # passing for a required status check, so an `if:` on the whole job would
-      # reintroduce the same hole.
-      #
-      # Only upstream pushes are affected. On a fork the gate returns run=true
-      # and the jobs really do run, so a fork's own push CI stays intact.
-      - name: Fail unvalidated upstream push
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        run: |
-          echo "::error title=windows CI::no CI ran for this push; approving the PR triggers it" \
-            && exit 1
-
       - name: Report which dependency failed
         env:
           NEEDS: ${{ toJSON(needs) }}

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -17,8 +17,17 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
+    # This list is also what the approval gate re-applies on
+    # pull_request_review (see gate.yml). Because `required` below treats a
+    # skipped job as success, anything missing here makes `windows CI` go green
+    # without building - so every input this workflow's result depends on must
+    # be listed, including the reusable workflows and composite actions it
+    # calls and the gate machinery that decides whether it runs at all.
     paths:
+      - ".github/scripts/**"
+      - ".github/workflows/build_llvm_libraries.yml"
       - ".github/workflows/compilation_on_windows.yml"
+      - ".github/workflows/gate.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -62,6 +71,7 @@ jobs:
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
+    name: approval gate
     permissions:
       contents: read
       pull-requests: read
@@ -153,7 +163,8 @@ jobs:
 
   test:
     runs-on: windows-2022
-    needs: [build_iwasm, build_wamrc]
+    needs: gate
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -199,3 +210,63 @@ jobs:
         timeout-minutes: 20
         run: ./test_wamr.sh ${{ matrix.test_option }} -t ${{ matrix.running_mode }}
         working-directory: ./tests/wamr-test-suites
+
+  # Single stable check for branch protection. Set THIS as the required status
+  # check, never an individual job: matrix job names are built from the matrix
+  # dimensions, so every matrix refactor renames all of them and silently
+  # invalidates whatever was configured under Settings -> Branches.
+  #
+  # `if: always()` is mandatory. Without it this job is skipped whenever an
+  # upstream job fails, and a skipped job counts as passing for a required
+  # check - it would be a gate that is green forever.
+  #
+  # `skipped` must count as success: when the gate resolves to run=false (the
+  # PR does not touch this workflow's paths, or it is not the first approval)
+  # every job below is skipped, and that is the normal path.
+  required:
+    name: windows CI
+    if: always()
+    needs:
+      [
+        gate,
+        build_llvm_libraries_on_windows,
+        build_iwasm,
+        build_wamrc,
+        test,
+      ]
+    runs-on: ubuntu-22.04
+    steps:
+      # Close the window between "approved" and "the approval run registers its
+      # check". A push to an upstream branch resolves the gate to run=false, so
+      # every job above is skipped and the rule below would report a green
+      # `windows CI` on that head SHA. Since branch protection reads the latest
+      # check of that name, the PR would sit on a green required check for the
+      # whole interval between the approval and the new run appearing - long
+      # enough to merge with no CI having ever run. Reporting red instead is the
+      # accurate statement: this SHA has not been validated yet.
+      #
+      # This must FAIL, not be skipped: a skipped check run also counts as
+      # passing for a required status check, so an `if:` on the whole job would
+      # reintroduce the same hole.
+      #
+      # Only upstream pushes are affected. On a fork the gate returns run=true
+      # and the jobs really do run, so a fork's own push CI stays intact.
+      - name: Fail unvalidated upstream push
+        if: github.event_name == 'push' && github.event.repository.fork == false
+        run: |
+          echo "::error title=windows CI::no CI ran for this push; approving the PR triggers it" \
+            && exit 1
+
+      - name: Report which dependency failed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.value.result)\t\(.key)"' | sort
+          failed_jobs=$(echo "$NEEDS" | jq -r \
+            'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | .key' \
+            | paste -sd ', ' -)
+          if [ -n "$failed_jobs" ]; then
+            echo "::error title=windows CI::failed or cancelled dependency jobs: $failed_jobs"
+          fi
+          echo "$NEEDS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' \
+            > /dev/null

--- a/.github/workflows/compilation_on_zephyr.yml
+++ b/.github/workflows/compilation_on_zephyr.yml
@@ -169,32 +169,22 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    name: zephyr CI
-    if: always()
+    # Same as the `required` job in compilation_on_ubuntu.yml: the job name is
+    # the check run name the ruleset matches. On an upstream push this job is
+    # skipped (see the `if:`) and renamed to "zephyr CI (push)": the skipped
+    # run cannot be mistaken for a validation result, and the required "zephyr
+    # CI" name is produced only by the approval-triggered run - no green check
+    # before approval, no false red either.
+    name: zephyr CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # `always()` is mandatory: on approval-triggered runs this job must run
+    # and fail when any dependency failed (a skipped job counts as passing for
+    # a required check). Only an upstream push is exempt - the gate already
+    # resolved to run=false there, every dependency is skipped, and skipping
+    # this job too keeps the whole push run uniformly "did not run".
+    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
     needs: [gate, smoke_test]
     runs-on: ubuntu-22.04
     steps:
-      # Close the window between "approved" and "the approval run registers its
-      # check". A push to an upstream branch resolves the gate to run=false, so
-      # every job above is skipped and the rule below would report a green
-      # `zephyr CI` on that head SHA. Since branch protection reads the latest
-      # check of that name, the PR would sit on a green required check for the
-      # whole interval between the approval and the new run appearing - long
-      # enough to merge with no CI having ever run. Reporting red instead is the
-      # accurate statement: this SHA has not been validated yet.
-      #
-      # This must FAIL, not be skipped: a skipped check run also counts as
-      # passing for a required status check, so an `if:` on the whole job would
-      # reintroduce the same hole.
-      #
-      # Only upstream pushes are affected. On a fork the gate returns run=true
-      # and the jobs really do run, so a fork's own push CI stays intact.
-      - name: Fail unvalidated upstream push
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        run: |
-          echo "::error title=zephyr CI::no CI ran for this push; approving the PR triggers it" \
-            && exit 1
-
       - name: Report which dependency failed
         env:
           NEEDS: ${{ toJSON(needs) }}

--- a/.github/workflows/compilation_on_zephyr.yml
+++ b/.github/workflows/compilation_on_zephyr.yml
@@ -17,8 +17,16 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
+    # This list is also what the approval gate re-applies on
+    # pull_request_review (see gate.yml). Because `required` below treats a
+    # skipped job as success, anything missing here makes `zephyr CI` go green
+    # without building - so every input this workflow's result depends on must
+    # be listed, including the reusable workflows and composite actions it
+    # calls and the gate machinery that decides whether it runs at all.
     paths:
+      - ".github/scripts/**"
       - ".github/workflows/compilation_on_zephyr.yml"
+      - ".github/workflows/gate.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -59,6 +67,7 @@ jobs:
   # skipped: a skipped job propagates the skip down the needs chain to every
   # descendant, even ones that broke the chain with their own `if`.
   gate:
+    name: approval gate
     permissions:
       contents: read
       pull-requests: read
@@ -146,3 +155,56 @@ jobs:
           .github/scripts/run_qemu_and_verify.sh \
             product-mini/platforms/zephyr/${{ matrix.sample.path }}/build 10 ${{ matrix.sample.verify }}
         working-directory: modules/wasm-micro-runtime
+
+  # Single stable check for branch protection. Set THIS as the required status
+  # check, never an individual job: matrix job names are built from the matrix
+  # dimensions, so every matrix refactor renames all of them and silently
+  # invalidates whatever was configured under Settings -> Branches.
+  #
+  # `if: always()` is mandatory. Without it this job is skipped whenever an
+  # upstream job fails, and a skipped job counts as passing for a required
+  # check - it would be a gate that is green forever.
+  #
+  # `skipped` must count as success: when the gate resolves to run=false (the
+  # PR does not touch this workflow's paths, or it is not the first approval)
+  # every job below is skipped, and that is the normal path.
+  required:
+    name: zephyr CI
+    if: always()
+    needs: [gate, smoke_test]
+    runs-on: ubuntu-22.04
+    steps:
+      # Close the window between "approved" and "the approval run registers its
+      # check". A push to an upstream branch resolves the gate to run=false, so
+      # every job above is skipped and the rule below would report a green
+      # `zephyr CI` on that head SHA. Since branch protection reads the latest
+      # check of that name, the PR would sit on a green required check for the
+      # whole interval between the approval and the new run appearing - long
+      # enough to merge with no CI having ever run. Reporting red instead is the
+      # accurate statement: this SHA has not been validated yet.
+      #
+      # This must FAIL, not be skipped: a skipped check run also counts as
+      # passing for a required status check, so an `if:` on the whole job would
+      # reintroduce the same hole.
+      #
+      # Only upstream pushes are affected. On a fork the gate returns run=true
+      # and the jobs really do run, so a fork's own push CI stays intact.
+      - name: Fail unvalidated upstream push
+        if: github.event_name == 'push' && github.event.repository.fork == false
+        run: |
+          echo "::error title=zephyr CI::no CI ran for this push; approving the PR triggers it" \
+            && exit 1
+
+      - name: Report which dependency failed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.value.result)\t\(.key)"' | sort
+          failed_jobs=$(echo "$NEEDS" | jq -r \
+            'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | .key' \
+            | paste -sd ', ' -)
+          if [ -n "$failed_jobs" ]; then
+            echo "::error title=zephyr CI::failed or cancelled dependency jobs: $failed_jobs"
+          fi
+          echo "$NEEDS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' \
+            > /dev/null


### PR DESCRIPTION
Port the ubuntu workflow's PR-gate hardening (680b8d02, 4456eb92) to macos, nuttx, sgx, windows and zephyr, and finish the android half.

## Break the false `needs:` dependencies
No job in any of these workflows uploads an artifact, so every `needs:` was a serialisation barrier. The sample and spec-test jobs build their own iwasm/wamrc but waited behind the whole build_iwasm matrix:
- macos: `build_samples_wasm_c_api`, `build_samples_others` drop `build_iwasm`.
- sgx: `run_samples_file`, `spec_test_default` drop `build_iwasm`.
- windows: `test` drops `build_iwasm` and `build_wamrc`; it now gates on the gate job directly, so it still respects the approval gate while starting immediately.

## Aggregate `required` checks
Each workflow gains a stable check for branch protection - `macos CI`, `nuttx CI`, `sgx CI`, `windows CI`, `zephyr CI` - that fails unless every other job succeeded or was skipped (`if: always()`, skipped counts as success, exactly as in the ubuntu workflow). `android CI` gains the same hardening steps it was missing.

## Path filters
Every input the result depends on is now listed in `on.push.paths`: `gate.yml`, `.github/scripts/**` (the gate's path-filter helper, and zephyr's own QEMU runner), `.github/actions/**` (composite actions used by macos/sgx), and `build_llvm_libraries.yml` which windows referenced but never filtered on. A missing entry would make the required check go green without building.

Note: if these checks are to be enforced, the new names (`macos CI`, `nuttx CI`, `sgx CI`, `windows CI`, `zephyr CI`) must be added under Settings -> Branches at merge time.
