### PR TITLE
build_llvm.py: retry the --llvm-ver GitHub API query with backoff

### DIFF
--- a/build-scripts/build_llvm.py
+++ b/build-scripts/build_llvm.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sysconfig
 import sys
+import time
 
 
 def clone_llvm(dst_dir, llvm_repo, llvm_branch):
@@ -37,15 +38,22 @@ def query_llvm_version(llvm_info):
         'Authorization': f"Bearer {github_token}"
     }
 
-    try:
-        response = requests.request("GET", url, headers=headers, data={})
-        response.raise_for_status()
-    except requests.exceptions.HTTPError as error:
-        print (error) # for debugging purpose
-        return None
-
-    response = response.json()
-    return response['sha']
+    # Retry with exponential backoff. The GitHub API intermittently returns
+    # transient 5xx responses or drops the connection; without a retry a single
+    # blip returns None here and aborts the whole prebuilt-LLVM CI job.
+    max_attempts = 5
+    for attempt in range(max_attempts):
+        try:
+            response = requests.request(
+                "GET", url, headers=headers, data={}, timeout=30
+            )
+            response.raise_for_status()
+            return response.json()['sha']
+        except requests.exceptions.RequestException as error:
+            print(error)  # for debugging purpose
+            if attempt + 1 >= max_attempts:
+                return None
+            time.sleep(2**attempt)  # 1s, 2s, 4s, 8s
 
 
 def build_llvm(llvm_dir, platform, backends, projects, use_clang=False, extra_flags='', use_ccache=False):


### PR DESCRIPTION
## What this fixes

`query_llvm_version()` (used by `build_llvm.py --llvm-ver` in the reusable `build_llvm_libraries.yml` job) resolves the LLVM commit SHA with a **single** GET to `api.github.com`. On any transient failure — a 5xx, a dropped connection, a hang — it prints the error and returns `None`, and the workflow step then writes a bare `None` line into `$GITHUB_OUTPUT`:

```
echo "last_commit=$(python3 ./build_llvm.py --llvm-ver)" >> $GITHUB_OUTPUT
```

GitHub Actions rejects that as `Invalid format 'None'`, killing the `build_llvm` job in ~3 minutes — and with it every workflow leg that `needs:` the prebuilt-LLVM cache. A single API blip fails an otherwise-healthy run at its very first step. We hit exactly this during an api.github.com incident.

## The change (+17/−9, no behavior change on the happy path)

- Retry the request up to 5 times with exponential backoff (1s/2s/4s/8s).
- Add `timeout=30` so a hung connection can't stall the job indefinitely.
- Catch `requests.exceptions.RequestException` (superset of `HTTPError`) so connection-level errors are retried too, not only HTTP status errors.
- Unchanged: same URL, headers, token use, and return contract (`sha` on success, `None` after final failure).

Verified by running the patched script in a fork CI diagnostic run: the query succeeded and the downstream cache-key step consumed the SHA normally.