### PR TITLE
test_wamr.sh: fetch the wabt binary release with curl instead of wget

### DIFF
--- a/.github/actions/install-wasi-sdk-wabt/action.yml
+++ b/.github/actions/install-wasi-sdk-wabt/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         SDK_DIR="wasi-sdk-${SDK_VER}.0-x86_64-linux"
         echo "Downloading wasi-sdk for Ubuntu..."
-        sudo wget -O wasi-sdk.tar.gz --progress=dot:giga \
+        sudo curl -fsSL -o wasi-sdk.tar.gz \
           "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${SDK_VER}/${SDK_DIR}.tar.gz"
 
         echo "Extracting wasi-sdk..."
@@ -49,7 +49,7 @@ runs:
         sudo ln -sf "${SDK_DIR}/" wasi-sdk
 
         echo "Downloading wabt for Ubuntu..."
-        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/1.0.37/wabt-1.0.37-ubuntu-20.04.tar.gz
+        sudo curl -fsSL -o wabt.tar.gz https://github.com/WebAssembly/wabt/releases/download/1.0.37/wabt-1.0.37-ubuntu-20.04.tar.gz
 
         echo "Extracting wabt..."
         sudo tar -xf wabt.tar.gz
@@ -69,7 +69,7 @@ runs:
       run: |
         SDK_DIR="wasi-sdk-${SDK_VER}.0-x86_64-macos"
         echo "Downloading wasi-sdk for macOS on Intel..."
-        sudo wget -O wasi-sdk.tar.gz --progress=dot:giga \
+        sudo curl -fsSL -o wasi-sdk.tar.gz \
           "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${SDK_VER}/${SDK_DIR}.tar.gz"
 
         echo "Extracting wasi-sdk..."
@@ -77,7 +77,7 @@ runs:
         sudo ln -sf "${SDK_DIR}" wasi-sdk
 
         echo "Downloading wabt for macOS on Intel..."
-        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/1.0.36/wabt-1.0.36-macos-12.tar.gz
+        sudo curl -fsSL -o wabt.tar.gz https://github.com/WebAssembly/wabt/releases/download/1.0.36/wabt-1.0.36-macos-12.tar.gz
 
         echo "Extracting wabt..."
         sudo tar -xf wabt.tar.gz
@@ -97,7 +97,7 @@ runs:
       run: |
         SDK_DIR="wasi-sdk-${SDK_VER}.0-arm64-macos"
         echo "Downloading wasi-sdk for macOS on ARM..."
-        sudo wget -O wasi-sdk.tar.gz --progress=dot:giga \
+        sudo curl -fsSL -o wasi-sdk.tar.gz \
           "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${SDK_VER}/${SDK_DIR}.tar.gz"
 
         echo "Extracting wasi-sdk..."
@@ -105,7 +105,7 @@ runs:
         sudo ln -sf "${SDK_DIR}" wasi-sdk
 
         echo "Downloading wabt for macOS on ARM..."
-        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/1.0.37/wabt-1.0.37-macos-14.tar.gz
+        sudo curl -fsSL -o wabt.tar.gz https://github.com/WebAssembly/wabt/releases/download/1.0.37/wabt-1.0.37-macos-14.tar.gz
 
         echo "Extracting wabt..."
         sudo tar -xf wabt.tar.gz
@@ -123,20 +123,18 @@ runs:
       env:
         SDK_VER: ${{ inputs.wasi_sdk_version }}
       run: |
-        choco install -y wget
-
         mkdir -p /opt/wasi-sdk
         mkdir -p /opt/wabt
 
         echo "Downloading wasi-sdk for Windows..."
-        wget -O wasi-sdk.tar.gz --progress=dot:giga \
+        curl -fsSL -o wasi-sdk.tar.gz \
           "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${SDK_VER}/wasi-sdk-${SDK_VER}.0-x86_64-windows.tar.gz"
 
         echo "Extracting wasi-sdk..."
         tar --strip-components=1 -xf wasi-sdk.tar.gz -C /opt/wasi-sdk
 
         echo "Downloading wabt for Windows..."
-        wget -O wabt.tar.gz --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/1.0.37/wabt-1.0.37-windows.tar.gz
+        curl -fsSL -o wabt.tar.gz https://github.com/WebAssembly/wabt/releases/download/1.0.37/wabt-1.0.37-windows.tar.gz
 
         echo "Extracting wabt..."
         tar --strip-components=1 -xf wabt.tar.gz -C /opt/wabt

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -204,10 +204,6 @@ jobs:
         run: ./build.sh
         working-directory: ./core/iwasm/libraries/lib-wasi-threads/test/
 
-      - name: install wget
-        shell: bash
-        run: choco install wget
-
       - name: run tests
         shell: bash
         timeout-minutes: 20

--- a/.github/workflows/compilation_on_zephyr.yml
+++ b/.github/workflows/compilation_on_zephyr.yml
@@ -115,6 +115,12 @@ jobs:
           ref: ${{ env.PR_REF }}
           path: modules/wasm-micro-runtime
 
+      # ci-base does not ship curl, which the action below uses to fetch
+      # the wasi-sdk and wabt release tarballs.
+      - name: Install curl
+        shell: bash
+        run: apt-get update && apt-get install -y curl
+
       - name: Install wasi-sdk and wabt
         uses: ./modules/wasm-micro-runtime/.github/actions/install-wasi-sdk-wabt
         with:

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -493,7 +493,7 @@ function setup_wabt()
         local WAT2WASM=${WORK_DIR}/wabt/out/gcc/Release/wat2wasm
         if [ ! -f ${WAT2WASM} ]; then
             pushd /tmp
-            curl -L -o wabt-tar.gz ${WABT_URL}
+            curl -fL -o wabt-tar.gz ${WABT_URL} || exit 1
             tar xf wabt-tar.gz
             popd
 

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -493,7 +493,7 @@ function setup_wabt()
         local WAT2WASM=${WORK_DIR}/wabt/out/gcc/Release/wat2wasm
         if [ ! -f ${WAT2WASM} ]; then
             pushd /tmp
-            wget -O wabt-tar.gz --progress=dot:giga ${WABT_URL}
+            curl -L -o wabt-tar.gz ${WABT_URL}
             tar xf wabt-tar.gz
             popd
 


### PR DESCRIPTION
## What breaks

The `windows-2022` runner image no longer ships `wget` in its bash environment. Every spec-test leg that uses the `-b` wabt-binary-release path (e.g. `test (classic-interp, $THREADS_TEST_OPTIONS)` in `compilation_on_windows.yml`) now dies during setup:

```
./test_wamr.sh: line 529: wget: command not found
tar: wabt-tar.gz: Cannot open: No such file or directory
Can not find ./wabt/out/gcc/Release/wat2wasm.exe
spec tests FAILED
```

The workflow's last green run on main was 2026-07-27, which predates the runner-image update — the next windows run on main will hit this. (Observed on a fork running the identical workflow today.)

## Fix

Fetch the release with `curl -L`, which is preinstalled on all hosted runners including Windows. One line, no behavior change on the happy path.