### PR TITLE
tests/unit: fetch cmocka from the GitLab mirror, pinned by hash

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -78,13 +78,15 @@ FetchContent_MakeAvailable(googletest)
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
   FetchContent_Declare(
     cmocka
-    URL https://git.cryptomilk.org/projects/cmocka.git/snapshot/cmocka-2.0.1.tar.gz
+    URL https://gitlab.com/cmocka/cmocka/-/archive/cmocka-2.0.1/cmocka-cmocka-2.0.1.tar.gz
+    URL_HASH SHA256=44a229d3f599a593606d895b175504a642078bec8e8d8a9c30ca49c6605b621d
     DOWNLOAD_EXTRACT_TIMESTAMP ON
   )
 else()
   FetchContent_Declare(
     cmocka
-    URL https://git.cryptomilk.org/projects/cmocka.git/snapshot/cmocka-2.0.1.tar.gz
+    URL https://gitlab.com/cmocka/cmocka/-/archive/cmocka-2.0.1/cmocka-cmocka-2.0.1.tar.gz
+    URL_HASH SHA256=44a229d3f599a593606d895b175504a642078bec8e8d8a9c30ca49c6605b621d
   )
 endif()
 FetchContent_MakeAvailable(cmocka)


### PR DESCRIPTION
## What breaks

`tests/unit/CMakeLists.txt` fetches cmocka from `git.cryptomilk.org`'s cgit snapshot endpoint, which generates archives on the fly and intermittently serves error pages under load. When several unit-test jobs run in parallel, FetchContent saves the error page as the tarball and the configure step dies before any test builds:

```
CMake Error: Problem extracting tar: .../cmocka-2.0.1.tar.gz
CMake Error: Problem with archive_read_open_file(): Unrecognized archive format
```

Observed repeatedly today across `unit tests (X86_64)` / `unit tests (X86_32)` legs on a fork running the identical workflow (while the same URL served a valid archive between runs — it is load-dependent).

## Fix

Fetch the same `cmocka-2.0.1` release from the project's official GitLab mirror (`gitlab.com/cmocka/cmocka`), whose archive endpoint is CDN-backed, and pin it with `URL_HASH SHA256=...`. I verified the extracted trees of the cryptomilk and GitLab archives are identical. The hash also turns any future bad download into a loud, immediate failure instead of an inscrutable extraction error.