### PR TITLE
ci: keep upstream-push gate reds off required check names

### DIFF
--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -186,21 +186,22 @@ jobs:
   # Single stable check for branch protection. Configure this job, rather than
   # individual lint jobs, as the required status check in the repository ruleset.
   required:
-    name: coding guidelines
-    if: always()
+    # Same pattern as the `required` job in compilation_on_ubuntu.yml: the job
+    # name is the check run name the ruleset matches. On an upstream push this
+    # job is skipped (see the `if:`) and renamed to "coding guidelines (push)":
+    # the skipped run cannot be mistaken for a validation result, and the
+    # required "coding guidelines" name is produced only by the
+    # approval-triggered run - no green check before approval, no false red.
+    name: coding guidelines${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # `always()` is mandatory: on approval-triggered runs this job must run
+    # and fail when any dependency failed (a skipped job counts as passing for
+    # a required check). Only an upstream push is exempt - the gate already
+    # resolved to run=false there, every dependency is skipped, and skipping
+    # this job too keeps the whole push run uniformly "did not run".
+    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
     needs: [gate, changes, compliance_job, actionlint, hadolint]
     runs-on: ubuntu-24.04
     steps:
-      # An upstream push makes the gate skip the lint jobs. It must report a
-      # failure instead of passing on the new SHA while it awaits approval:
-      # branch protection otherwise accepts the prior approval run's green
-      # check until the next approval-triggered run is registered.
-      - name: Fail unvalidated upstream push
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        run: |
-          echo "::error title=coding guidelines::no CI ran for this push; approving the PR triggers it" \
-            && exit 1
-
       - name: Report which dependency failed
         env:
           NEEDS: ${{ toJSON(needs) }}

--- a/.github/workflows/compilation_on_ubuntu.yml
+++ b/.github/workflows/compilation_on_ubuntu.yml
@@ -852,8 +852,19 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    name: ubuntu CI
-    if: always()
+    # `name:` doubles as the check run name, which is what the ruleset's
+    # required_status_checks matches. On an upstream push this job is skipped
+    # (see the `if:`) and renamed to "ubuntu CI (push)": the skipped run
+    # cannot be mistaken for a validation result, and the required "ubuntu CI"
+    # name is produced only by the approval-triggered run - no green check
+    # before approval, no false red either.
+    name: ubuntu CI${{ github.event_name == 'push' && github.event.repository.fork == false && ' (push)' || '' }}
+    # `always()` is mandatory: on approval-triggered runs this job must run
+    # and fail when any dependency failed (a skipped job counts as passing for
+    # a required check). Only an upstream push is exempt - the gate already
+    # resolved to run=false there, every dependency is skipped, and skipping
+    # this job too keeps the whole push run uniformly "did not run".
+    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
     needs:
       [
         gate,
@@ -869,27 +880,6 @@ jobs:
       ]
     runs-on: ubuntu-22.04
     steps:
-      # Close the window between "approved" and "the approval run registers its
-      # check". A push to an upstream branch resolves the gate to run=false, so
-      # every job above is skipped and the rule below would report a green
-      # `ubuntu CI` on that head SHA. Since branch protection reads the latest
-      # check of that name, the PR would sit on a green required check for the
-      # whole interval between the approval and the new run appearing - long
-      # enough to merge with no CI having ever run. Reporting red instead is the
-      # accurate statement: this SHA has not been validated yet.
-      #
-      # This must FAIL, not be skipped: a skipped check run also counts as
-      # passing for a required status check, so an `if:` on the whole job would
-      # reintroduce the same hole.
-      #
-      # Only upstream pushes are affected. On a fork the gate returns run=true
-      # and the jobs really do run, so a fork's own push CI stays intact.
-      - name: Fail unvalidated upstream push
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        run: |
-          echo "::error title=ubuntu CI::no CI ran for this push; approving the PR triggers it" \
-            && exit 1
-
       - name: Report which dependency failed
         env:
           NEEDS: ${{ toJSON(needs) }}


### PR DESCRIPTION
The ruleset requires checks named exactly "ubuntu CI" and "coding guidelines". GitHub evaluates a required check name against every run of that name on the head commit, not just the latest one, so the deliberate "Fail unvalidated upstream push" failure on a direct upstream push keeps the PR blocked even after the approval-triggered run passes.

Rename the required job on upstream pushes (event_name == push && !fork) to "ubuntu CI (push)" / "coding guidelines (push)": the failure stays visible as "this SHA has not been validated yet" but no longer collides with the required check name, which is then produced only by the approval-triggered run. Fork push CI and workflow_dispatch keep the plain names and real CI.