### PR TITLE
esp-idf: fix GCC 15 format-security build

### DIFF
--- a/build-scripts/esp-idf/wamr/CMakeLists.txt
+++ b/build-scripts/esp-idf/wamr/CMakeLists.txt
@@ -94,7 +94,11 @@ idf_component_register(SRCS ${srcs}
                        REQUIRES pthread lwip esp_timer
                        KCONFIG ${CMAKE_CURRENT_LIST_DIR}/Kconfig)
 
-target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")
+# ESP-IDF enables -Wformat-security by default.  It must be disabled together
+# with -Wformat, otherwise GCC 15 reports an option mismatch under -Werror.
+target_compile_options(${COMPONENT_LIB} PRIVATE
+                       "-Wno-format"
+                       "-Wno-format-security")
 
 if (CONFIG_IDF_TARGET_ARCH_RISCV)
   if (CONFIG_IDF_TARGET_ESP32P4)


### PR DESCRIPTION
Fixes #5065.

## Summary

- disable `-Wformat-security` together with the component's existing `-Wno-format` option
- avoid GCC 15 rejecting contradictory warning flags when ESP-IDF enables `-Werror`
- preserve the component's existing format-warning policy

## Validation

Tested with the bundled `product-mini/platforms/esp-idf` example using:

- ESP-IDF commit `6a9c44fe7e725af45cb99293ae38afd7d481f1e3`
- GCC 15.2.0
- ESP32-P4

Before this change, compilation stops immediately with:

```
cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
```

After this change, the compiler accepts the warning options and proceeds through WAMR compilation. The standalone example then encounters a separate pre-existing ESP-IDF 6.1 transitive-header issue tracked in #5066. In an integration that supplies those missing declarations, the complete ESP32-P4 firmware builds and links successfully.

No runtime behavior is changed.