### PR TITLE
esp-idf: include required POSIX declarations

### DIFF
--- a/core/shared/platform/esp-idf/platform_internal.h
+++ b/core/shared/platform/esp-idf/platform_internal.h
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <arpa/inet.h>
+#include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
 #include <dirent.h>
@@ -30,6 +31,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Implemented by espidf_platform.c when ESP-IDF doesn't provide it. */
+int
+renameat(int old_dirfd, const char *old_path, int new_dirfd,
+         const char *new_path);
 
 #ifndef BH_PLATFORM_ESP_IDF
 #define BH_PLATFORM_ESP_IDF

--- a/core/shared/platform/esp-idf/platform_internal.h
+++ b/core/shared/platform/esp-idf/platform_internal.h
@@ -32,10 +32,12 @@
 extern "C" {
 #endif
 
-/* Implemented by espidf_platform.c when ESP-IDF doesn't provide it. */
+#if defined(__PICOLIBC__)
+/* Picolibc omits this declaration; espidf_platform.c defines the stub. */
 int
 renameat(int old_dirfd, const char *old_path, int new_dirfd,
          const char *new_path);
+#endif
 
 #ifndef BH_PLATFORM_ESP_IDF
 #define BH_PLATFORM_ESP_IDF


### PR DESCRIPTION
Fixes #5066.

## Summary

- include `<sys/stat.h>` explicitly in the ESP-IDF platform header
- declare the local `renameat()` fallback implemented by `espidf_platform.c`
- avoid relying on POSIX declarations that ESP-IDF 6.1 no longer provides transitively

## Validation

Tested with the bundled `product-mini/platforms/esp-idf` example using:

- ESP-IDF commit `6a9c44fe7e725af45cb99293ae38afd7d481f1e3`
- GCC 15.2.0
- ESP32-P4
- the independent warning-option fix from #5067 applied locally

Before this change, `espidf_file.c` and `espidf_platform.c` fail on an undefined `struct stat` and implicit declarations of `fstatat`, `renameat`, and related POSIX functions. After this change, those ESP-IDF platform sources compile successfully. The example later reaches a separate existing libc-wasi `os_timespec` incompatibility tracked in #5068.

Formatting and checks:

- formatted with Espressif clang-format 21.1.3 using the repository style
- `git diff --check` passes
- `clang-tidy-diff.py` reports no directly matched compilation unit for this header-only change

No runtime behavior is changed.