### PR TITLE
Summarize the Current CI Gate Model

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,43 @@
+# 📌 CI and Ruleset Gates Architecture
+
+This document specifies the GitHub Actions workflow triggers, approval gates, and branch ruleset configurations for the WebAssembly Micro Runtime (WAMR) repository.
+
+### 🛡️ Repository Ruleset Policies
+
+| Policy                       | Configuration & Enforcement                                                                                            |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Pull Request Reviews**     | Mandatory before merging.                                                                                              |
+| **Commit-Level Approval**    | Requires an explicit approval targeting the **latest head commit** of the PR.                                          |
+| **Approval Invalidation**    | Automatically dismisses stale reviews upon new commit pushes (`synchronize`).                                          |
+| **Status Check Enforcement** | Requires canonical status checks to pass before merging. Current mandatory gates: `ubuntu CI` and `coding guidelines`. |
+| **Merge Queue**              | **Disabled** (standard PR merge flow).                                                                                 |
+
+> ℹ️ **Note on Check Evaluation:** GitHub evaluates required checks by their **exact check-run name**. A status of `skipped` is treated as passing by GitHub rulesets, allowing path-filtered and gated runs to satisfy merge requirements without executing redundant compute jobs.
+
+### ⚙️ CI Approval & Execution Logic
+
+Real upstream CI execution is strictly **approval-gated** to optimize runner resources and enhance security:
+
+| Operational State                                  | Upstream CI Behavior                                                        | Canonical Check Name / Status                                 |
+| -------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| **PR Lifecycle Events** (`opened` / `reopened`)    | Real CI is **not** triggered.                                               | None (awaits review).                                         |
+| **Initial Review Approval**                        | Triggers full CI on the approved `head SHA` if relevant files are modified. | `ubuntu CI` (`success` / `failure`)                           |
+| **PR Sync with Valid Approval**                    | Triggers full CI only if approval remains active on the new commit.         | `ubuntu CI` (`success` / `failure`)                           |
+| **PR Sync without Approval / Non-Approval Review** | No expensive compute triggered.                                             | Non-required check `ubuntu CI awaiting approval` (`skipped`). |
+| **Approved PR without Relevant Changes**           | Path filtering bypasses test jobs.                                          | `ubuntu CI` (`skipped`).                                      |
+| **Duplicate Approval on Same SHA**                 | Bypasses redundant CI execution.                                            | Non-required check `ubuntu CI approved` (`skipped`).          |
+
+#### Ref Resolution & Invalidation Rules
+
+- **Target Ref:** PR jobs checkout `refs/pull/<number>/merge`, validating the projected merge commit formed by the PR head and target base branch.
+- **Stale Review Semantics:** Governed directly by GitHub Ruleset settings; workflow triggers strictly consume the resulting approval state without attempting diff heuristics.
+
+### 🚀 Push Event Triggers & Branch Filtering
+
+Push workflows apply differentiated execution paths based on repository origin and branch patterns:
+
+| Context             | Branch Matching Rule           | Execution Outcome                       | Check Name & Status                         |
+| ------------------- | ------------------------------ | --------------------------------------- | ------------------------------------------- |
+| **Branch Filtered** | `main`, `release/**`, `dev/**` | Workflow skipped via `branches-ignore`. | No check produced.                          |
+| **Fork Push**       | Non-filtered branches          | Executes full CI matrix.                | `ubuntu CI on push` (`success` / `failure`) |
+| **Upstream Push**   | Non-filtered branches          | Gate job skips expensive execution.     | `ubuntu CI on push` (`skipped`)             |

--- a/.github/workflows/build_llvm_libraries.yml
+++ b/.github/workflows/build_llvm_libraries.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: ""
+      pr_ref:
+        description: optional ref to check out, such as a pull request merge ref
+        required: false
+        type: string
+        default: ""
     outputs:
       cache_key:
         description: "A cached key of LLVM libraries"
@@ -46,6 +51,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ inputs.pr_ref }}
 
       - name: install dependencies for non macos
         if: ${{ !startsWith(inputs.os, 'macos') }}

--- a/.github/workflows/check_version_h.yml
+++ b/.github/workflows/check_version_h.yml
@@ -4,6 +4,12 @@ name: confirm version.h stay in sync
 
 on:
   workflow_call:
+    inputs:
+      pr_ref:
+        description: optional ref to check out, such as a pull request merge ref
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -15,6 +21,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ inputs.pr_ref }}
 
       - name: cmake execute to generate version.h
         run: cmake -B build_version -S .

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,19 +17,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    # Only the code CodeQL actually compiles (see codeql_buildscript.sh:
-    # wamr-compiler + product-mini/platforms/linux) plus the scan recipe and
-    # config. samples/** and tests/** are never built here, so scanning them
-    # on push would change nothing.
-    paths:
-      - ".github/workflows/codeql.yml"
-      - ".github/scripts/codeql_buildscript.sh"
-      - ".github/codeql/**"
-      - "build-scripts/**"
-      - "core/**"
-      - "!core/deps/**"
-      - "product-mini/**"
-      - "wamr-compiler/**"
   # Upstream CI: on the first approval, re-run once - but only when the PR
   # changed the CodeQL pipeline itself (gate.paths below). Regular source
   # changes are covered by the nightly cron, not per-PR.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,6 +56,7 @@ jobs:
     with:
       paths: |
         .github/workflows/codeql.yml
+        .github/workflows/gate.yml
         .github/scripts/codeql_buildscript.sh
         .github/scripts/codeql_fail_on_error.py
         .github/codeql/**

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -191,15 +191,15 @@ jobs:
   # Single stable check for branch protection. Configure this job, rather than
   # individual lint jobs, as the required status check in the repository ruleset.
   required:
-    # Same pattern as the `required` job in compilation_on_ubuntu.yml: keep
-    # the canonical required-check name only when gate.run=true.
-    name: coding guidelines${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
-    # `always()` is mandatory: on approval-triggered runs this job must run
-    # and fail when any dependency failed (a skipped job counts as passing for
-    # a required check). Only an upstream push is exempt - the gate already
-    # resolved to run=false there, every dependency is skipped, and skipping
-    # this job too keeps the whole push run uniformly "did not run".
-    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
+    name: >-
+      ${{ needs.gate.outputs.state == 'push' && 'coding guidelines on push'
+      || needs.gate.outputs.state == 'awaiting' && 'coding guidelines awaiting approval'
+      || needs.gate.outputs.state == 'approved' && 'coding guidelines approved'
+      || 'coding guidelines' }}
+    # `always()` is mandatory when this job is expected to run: it must fail
+    # when any dependency failed. Waiting/duplicate-approval states are
+    # intentionally skipped with their non-required names.
+    if: always() && needs.gate.outputs.run == 'true'
     needs: [gate, changes, compliance_job, actionlint, hadolint]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/compilation_on_android.yml
+++ b/.github/workflows/compilation_on_android.yml
@@ -20,18 +20,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    # Narrower than the ubuntu workflow: android builds iwasm only, so
-    # wamr-compiler, the test suites and wamr-ide are irrelevant here.
-    # Every input the result depends on must be listed, including the gate
-    # machinery - see the same block in compilation_on_ubuntu.yml.
-    paths:
-      - ".github/scripts/**"
-      - ".github/workflows/compilation_on_android.yml"
-      - ".github/workflows/gate.yml"
-      - "build-scripts/**"
-      - "core/**"
-      - "!core/deps/**"
-      - "product-mini/platforms/android/**"
   # Upstream CI: only spend upstream minutes once a PR is approved
   # (first approval only, enforced by the gate job below).
   pull_request_review:
@@ -74,6 +62,15 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
+    with:
+      paths: |
+        .github/scripts/**
+        .github/workflows/compilation_on_android.yml
+        .github/workflows/gate.yml
+        build-scripts/**
+        core/**
+        !core/deps/**
+        product-mini/platforms/android/**
 
   # TODO: 44 jobs is far more android coverage than the incremental signal
   # justifies - android differs from linux only by core/shared/platform/android
@@ -157,8 +154,12 @@ jobs:
   # Single stable check for branch protection - see the same job in
   # compilation_on_ubuntu.yml for why an individual matrix job must not be used.
   required:
-    name: android CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
-    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
+    name: >-
+      ${{ needs.gate.outputs.state == 'push' && 'android CI on push'
+      || needs.gate.outputs.state == 'awaiting' && 'android CI awaiting approval'
+      || needs.gate.outputs.state == 'approved' && 'android CI approved'
+      || 'android CI' }}
+    if: always() && needs.gate.outputs.run == 'true'
     needs: [gate, build_iwasm]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -72,7 +72,8 @@ jobs:
         build-scripts/**
         core/**
         !core/deps/**
-        product-mini/**
+        product-mini/platforms/common/**
+        product-mini/platforms/darwin/**
         samples/**
         !samples/workload/**
         tests/wamr-test-suites/**

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -17,26 +17,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    # This list is also what the approval gate re-applies on
-    # pull_request_review (see gate.yml). Because `required` below treats a
-    # skipped job as success, anything missing here makes `macos CI` go green
-    # without building - so every input this workflow's result depends on must
-    # be listed, including the reusable workflows and composite actions it
-    # calls and the gate machinery that decides whether it runs at all.
-    paths:
-      - ".github/actions/**"
-      - ".github/scripts/**"
-      - ".github/workflows/build_llvm_libraries.yml"
-      - ".github/workflows/compilation_on_macos.yml"
-      - ".github/workflows/gate.yml"
-      - "build-scripts/**"
-      - "core/**"
-      - "!core/deps/**"
-      - "product-mini/**"
-      - "samples/**"
-      - "!samples/workload/**"
-      - "tests/wamr-test-suites/**"
-      - "wamr-compiler/**"
   # Upstream CI: only spend upstream minutes once a PR is approved
   # (first approval only, enforced by the gate job below).
   pull_request_review:
@@ -82,6 +62,21 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
+    with:
+      paths: |
+        .github/actions/**
+        .github/scripts/**
+        .github/workflows/build_llvm_libraries.yml
+        .github/workflows/compilation_on_macos.yml
+        .github/workflows/gate.yml
+        build-scripts/**
+        core/**
+        !core/deps/**
+        product-mini/**
+        samples/**
+        !samples/workload/**
+        tests/wamr-test-suites/**
+        wamr-compiler/**
   build_llvm_libraries_on_intel_macos:
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
@@ -92,6 +87,7 @@ jobs:
     with:
       os: "macos-15-intel"
       arch: "X86"
+      pr_ref: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
   build_llvm_libraries_on_arm_macos:
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
@@ -102,6 +98,7 @@ jobs:
     with:
       os: "macos-15"
       arch: "AArch64 ARM"
+      pr_ref: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
   build_wamrc:
     needs: [build_llvm_libraries_on_intel_macos, build_llvm_libraries_on_arm_macos]
@@ -505,15 +502,12 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: keep the
-    # canonical required-check name only when gate.run=true.
-    name: macos CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
-    # `always()` is mandatory: on approval-triggered runs this job must run
-    # and fail when any dependency failed (a skipped job counts as passing for
-    # a required check). Only an upstream push is exempt - the gate already
-    # resolved to run=false there, every dependency is skipped, and skipping
-    # this job too keeps the whole push run uniformly "did not run".
-    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
+    name: >-
+      ${{ needs.gate.outputs.state == 'push' && 'macos CI on push'
+      || needs.gate.outputs.state == 'awaiting' && 'macos CI awaiting approval'
+      || needs.gate.outputs.state == 'approved' && 'macos CI approved'
+      || 'macos CI' }}
+    if: always() && needs.gate.outputs.run == 'true'
     needs:
       [
         gate,

--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -17,24 +17,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    # This list is also what the approval gate re-applies on
-    # pull_request_review (see gate.yml). Because `required` below treats a
-    # skipped job as success, anything missing here makes `nuttx CI` go green
-    # without building - so every input this workflow's result depends on must
-    # be listed, including the reusable workflows and composite actions it
-    # calls and the gate machinery that decides whether it runs at all.
-    paths:
-      - ".github/scripts/**"
-      - ".github/workflows/compilation_on_nuttx.yml"
-      - ".github/workflows/gate.yml"
-      - "build-scripts/**"
-      - "core/**"
-      - "!core/deps/**"
-      - "product-mini/**"
-      - "samples/**"
-      - "!samples/workload/**"
-      - "tests/wamr-test-suites/**"
-      - "wamr-compiler/**"
   # Upstream CI: only spend upstream minutes once a PR is approved
   # (first approval only, enforced by the gate job below).
   pull_request_review:
@@ -77,6 +59,19 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
+    with:
+      paths: |
+        .github/scripts/**
+        .github/workflows/compilation_on_nuttx.yml
+        .github/workflows/gate.yml
+        build-scripts/**
+        core/**
+        !core/deps/**
+        product-mini/**
+        samples/**
+        !samples/workload/**
+        tests/wamr-test-suites/**
+        wamr-compiler/**
 
   # Build bloaty once and cache it, keyed on BLOATY_REF (a new ref -> cache
   # miss -> rebuild + refresh). The matrix below restores the prebuilt binary
@@ -242,15 +237,12 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: keep the
-    # canonical required-check name only when gate.run=true.
-    name: nuttx CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
-    # `always()` is mandatory: on approval-triggered runs this job must run
-    # and fail when any dependency failed (a skipped job counts as passing for
-    # a required check). Only an upstream push is exempt - the gate already
-    # resolved to run=false there, every dependency is skipped, and skipping
-    # this job too keeps the whole push run uniformly "did not run".
-    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
+    name: >-
+      ${{ needs.gate.outputs.state == 'push' && 'nuttx CI on push'
+      || needs.gate.outputs.state == 'awaiting' && 'nuttx CI awaiting approval'
+      || needs.gate.outputs.state == 'approved' && 'nuttx CI approved'
+      || 'nuttx CI' }}
+    if: always() && needs.gate.outputs.run == 'true'
     needs: [gate, build_bloaty, build_iwasm_on_nuttx]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -67,7 +67,8 @@ jobs:
         build-scripts/**
         core/**
         !core/deps/**
-        product-mini/**
+        product-mini/platforms/common/**
+        product-mini/platforms/nuttx/**
         samples/**
         !samples/workload/**
         tests/wamr-test-suites/**

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -17,26 +17,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    # This list is also what the approval gate re-applies on
-    # pull_request_review (see gate.yml). Because `required` below treats a
-    # skipped job as success, anything missing here makes `sgx CI` go green
-    # without building - so every input this workflow's result depends on must
-    # be listed, including the reusable workflows and composite actions it
-    # calls and the gate machinery that decides whether it runs at all.
-    paths:
-      - ".github/actions/**"
-      - ".github/scripts/**"
-      - ".github/workflows/build_llvm_libraries.yml"
-      - ".github/workflows/compilation_on_sgx.yml"
-      - ".github/workflows/gate.yml"
-      - "build-scripts/**"
-      - "core/**"
-      - "!core/deps/**"
-      - "product-mini/**"
-      - "samples/**"
-      - "!samples/workload/**"
-      - "tests/wamr-test-suites/**"
-      - "wamr-compiler/**"
   # Upstream CI: only spend upstream minutes once a PR is approved
   # (first approval only, enforced by the gate job below).
   pull_request_review:
@@ -85,6 +65,21 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
+    with:
+      paths: |
+        .github/actions/**
+        .github/scripts/**
+        .github/workflows/build_llvm_libraries.yml
+        .github/workflows/compilation_on_sgx.yml
+        .github/workflows/gate.yml
+        build-scripts/**
+        core/**
+        !core/deps/**
+        product-mini/**
+        samples/**
+        !samples/workload/**
+        tests/wamr-test-suites/**
+        wamr-compiler/**
   build_llvm_libraries:
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
@@ -95,6 +90,7 @@ jobs:
     with:
       os: ubuntu-22.04
       arch: "X86"
+      pr_ref: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
   build_iwasm:
     needs: gate
@@ -348,15 +344,12 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: keep the
-    # canonical required-check name only when gate.run=true.
-    name: sgx CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
-    # `always()` is mandatory: on approval-triggered runs this job must run
-    # and fail when any dependency failed (a skipped job counts as passing for
-    # a required check). Only an upstream push is exempt - the gate already
-    # resolved to run=false there, every dependency is skipped, and skipping
-    # this job too keeps the whole push run uniformly "did not run".
-    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
+    name: >-
+      ${{ needs.gate.outputs.state == 'push' && 'sgx CI on push'
+      || needs.gate.outputs.state == 'awaiting' && 'sgx CI awaiting approval'
+      || needs.gate.outputs.state == 'approved' && 'sgx CI approved'
+      || 'sgx CI' }}
+    if: always() && needs.gate.outputs.run == 'true'
     needs: [gate, build_llvm_libraries, build_iwasm, run_samples_file, spec_test_default]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -75,7 +75,8 @@ jobs:
         build-scripts/**
         core/**
         !core/deps/**
-        product-mini/**
+        product-mini/platforms/common/**
+        product-mini/platforms/linux-sgx/**
         samples/**
         !samples/workload/**
         tests/wamr-test-suites/**

--- a/.github/workflows/compilation_on_ubuntu.yml
+++ b/.github/workflows/compilation_on_ubuntu.yml
@@ -91,14 +91,14 @@ jobs:
         CMakeLists.txt
         core/**
         !core/deps/**
-        product-mini/**
+        product-mini/platforms/common/**
+        product-mini/platforms/linux/**
         samples/**
         !samples/workload/**
         tests/wamr-test-suites/**
         tests/unit/**
         tests/regression/**
         wamr-compiler/**
-        test-tools/wamr-ide/**
 
   check_version_h:
     name: version.h in sync

--- a/.github/workflows/compilation_on_ubuntu.yml
+++ b/.github/workflows/compilation_on_ubuntu.yml
@@ -20,35 +20,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    # This list is also what the approval gate re-applies on
-    # pull_request_review (see gate.yml). Because `required` below treats a
-    # skipped job as success, anything missing here makes `ubuntu CI` go green
-    # without building - so every input this workflow's result depends on must
-    # be listed, including the reusable workflows and composite actions it
-    # calls and the gate machinery that decides whether it runs at all.
-    paths:
-      - ".github/actions/**"
-      - ".github/scripts/**"
-      - ".github/workflows/build_llvm_libraries.yml"
-      - ".github/workflows/check_version_h.yml"
-      - ".github/workflows/compilation_on_ubuntu.yml"
-      - ".github/workflows/gate.yml"
-      - ".github/workflows/unit_test.yml"
-      - "build-scripts/**"
-      - "core/**"
-      # Only README.md and install_tensorflow.sh are tracked here; the latter
-      # serves samples/workload, which is excluded below. Everything else under
-      # core/deps is a downloaded or built dependency.
-      - "!core/deps/**"
-      - "product-mini/**"
-      - "samples/**"
-      - "!samples/workload/**"
-      - "tests/wamr-test-suites/**"
-      - "tests/unit/**"
-      # Source of the build_regression_tests job (tests/regression/ba-issues).
-      - "tests/regression/**"
-      - "wamr-compiler/**"
-      - "test-tools/wamr-ide/**"
   # Upstream CI: only spend upstream minutes once a PR is approved
   # (first approval only, enforced by the gate job below).
   pull_request_review:
@@ -107,6 +78,27 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
+    with:
+      paths: |
+        .github/actions/**
+        .github/scripts/**
+        .github/workflows/build_llvm_libraries.yml
+        .github/workflows/check_version_h.yml
+        .github/workflows/compilation_on_ubuntu.yml
+        .github/workflows/gate.yml
+        .github/workflows/unit_test.yml
+        build-scripts/**
+        CMakeLists.txt
+        core/**
+        !core/deps/**
+        product-mini/**
+        samples/**
+        !samples/workload/**
+        tests/wamr-test-suites/**
+        tests/unit/**
+        tests/regression/**
+        wamr-compiler/**
+        test-tools/wamr-ide/**
 
   check_version_h:
     name: version.h in sync
@@ -116,6 +108,8 @@ jobs:
       contents: read
       actions: write
     uses: ./.github/workflows/check_version_h.yml
+    with:
+      pr_ref: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
   build_llvm_libraries_on_ubuntu_2204:
     name: llvm libraries (ubuntu-22.04, X86)
@@ -128,6 +122,7 @@ jobs:
     with:
       os: "ubuntu-22.04"
       arch: "X86"
+      pr_ref: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
   build_wamrc:
     name: wamrc
@@ -804,16 +799,18 @@ jobs:
   # every job below is skipped, and that is the normal path.
   required:
     # `name:` doubles as the check run name, which is what the ruleset's
-    # required_status_checks matches. Keep the canonical "ubuntu CI" name only
-    # when gate.run=true (approval-triggered CI and post-rebase CI). Every
-    # other case gets a non-required alias.
-    name: ubuntu CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
-    # `always()` is mandatory: on approval-triggered runs this job must run
-    # and fail when any dependency failed (a skipped job counts as passing for
-    # a required check). Only an upstream push is exempt - the gate already
-    # resolved to run=false there, every dependency is skipped, and skipping
-    # this job too keeps the whole push run uniformly "did not run".
-    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
+    # required_status_checks matches. Waiting and duplicate-approval states
+    # use non-required aliases; an approved path skip keeps canonical
+    # "ubuntu CI" and is itself skipped.
+    name: >-
+      ${{ needs.gate.outputs.state == 'push' && 'ubuntu CI on push'
+      || needs.gate.outputs.state == 'awaiting' && 'ubuntu CI awaiting approval'
+      || needs.gate.outputs.state == 'approved' && 'ubuntu CI approved'
+      || 'ubuntu CI' }}
+    # `always()` is mandatory when this job is expected to run: it must fail
+    # when any dependency failed. Waiting/duplicate-approval states are
+    # intentionally skipped with their non-required names.
+    if: always() && needs.gate.outputs.run == 'true'
     needs:
       [
         gate,

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -64,6 +64,7 @@ jobs:
     uses: ./.github/workflows/gate.yml
     with:
       paths: |
+        .github/actions/**
         .github/scripts/**
         .github/workflows/build_llvm_libraries.yml
         .github/workflows/compilation_on_windows.yml
@@ -71,7 +72,8 @@ jobs:
         build-scripts/**
         core/**
         !core/deps/**
-        product-mini/**
+        product-mini/platforms/common/**
+        product-mini/platforms/windows/**
         samples/**
         !samples/workload/**
         tests/wamr-test-suites/**

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -17,25 +17,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    # This list is also what the approval gate re-applies on
-    # pull_request_review (see gate.yml). Because `required` below treats a
-    # skipped job as success, anything missing here makes `windows CI` go green
-    # without building - so every input this workflow's result depends on must
-    # be listed, including the reusable workflows and composite actions it
-    # calls and the gate machinery that decides whether it runs at all.
-    paths:
-      - ".github/scripts/**"
-      - ".github/workflows/build_llvm_libraries.yml"
-      - ".github/workflows/compilation_on_windows.yml"
-      - ".github/workflows/gate.yml"
-      - "build-scripts/**"
-      - "core/**"
-      - "!core/deps/**"
-      - "product-mini/**"
-      - "samples/**"
-      - "!samples/workload/**"
-      - "tests/wamr-test-suites/**"
-      - "wamr-compiler/**"
   # Upstream CI: only spend upstream minutes once a PR is approved
   # (first approval only, enforced by the gate job below).
   pull_request_review:
@@ -81,6 +62,20 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
+    with:
+      paths: |
+        .github/scripts/**
+        .github/workflows/build_llvm_libraries.yml
+        .github/workflows/compilation_on_windows.yml
+        .github/workflows/gate.yml
+        build-scripts/**
+        core/**
+        !core/deps/**
+        product-mini/**
+        samples/**
+        !samples/workload/**
+        tests/wamr-test-suites/**
+        wamr-compiler/**
   build_llvm_libraries_on_windows:
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
@@ -91,6 +86,7 @@ jobs:
     with:
       os: "windows-2022"
       arch: "AArch64 ARM Mips RISCV X86"
+      pr_ref: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
   build_iwasm:
     needs: gate
@@ -229,15 +225,12 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: keep the
-    # canonical required-check name only when gate.run=true.
-    name: windows CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
-    # `always()` is mandatory: on approval-triggered runs this job must run
-    # and fail when any dependency failed (a skipped job counts as passing for
-    # a required check). Only an upstream push is exempt - the gate already
-    # resolved to run=false there, every dependency is skipped, and skipping
-    # this job too keeps the whole push run uniformly "did not run".
-    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
+    name: >-
+      ${{ needs.gate.outputs.state == 'push' && 'windows CI on push'
+      || needs.gate.outputs.state == 'awaiting' && 'windows CI awaiting approval'
+      || needs.gate.outputs.state == 'approved' && 'windows CI approved'
+      || 'windows CI' }}
+    if: always() && needs.gate.outputs.run == 'true'
     needs:
       [
         gate,

--- a/.github/workflows/compilation_on_zephyr.yml
+++ b/.github/workflows/compilation_on_zephyr.yml
@@ -17,25 +17,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    # This list is also what the approval gate re-applies on
-    # pull_request_review (see gate.yml). Because `required` below treats a
-    # skipped job as success, anything missing here makes `zephyr CI` go green
-    # without building - so every input this workflow's result depends on must
-    # be listed, including the reusable workflows and composite actions it
-    # calls and the gate machinery that decides whether it runs at all.
-    paths:
-      - ".github/scripts/**"
-      - ".github/workflows/compilation_on_zephyr.yml"
-      - ".github/workflows/gate.yml"
-      - "build-scripts/**"
-      - "core/**"
-      - "!core/deps/**"
-      - "product-mini/platforms/common/**"
-      - "product-mini/platforms/zephyr/**"
-      - "samples/**"
-      - "!samples/workload/**"
-      - "tests/wamr-test-suites/**"
-      - "wamr-compiler/**"
   # Upstream CI: only spend upstream minutes once a PR is approved
   # (first approval only, enforced by the gate job below).
   pull_request_review:
@@ -78,6 +59,20 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
+    with:
+      paths: |
+        .github/scripts/**
+        .github/workflows/compilation_on_zephyr.yml
+        .github/workflows/gate.yml
+        build-scripts/**
+        core/**
+        !core/deps/**
+        product-mini/platforms/common/**
+        product-mini/platforms/zephyr/**
+        samples/**
+        !samples/workload/**
+        tests/wamr-test-suites/**
+        wamr-compiler/**
   smoke_test:
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}
@@ -197,15 +192,12 @@ jobs:
   # PR does not touch this workflow's paths, or it is not the first approval)
   # every job below is skipped, and that is the normal path.
   required:
-    # Same as the `required` job in compilation_on_ubuntu.yml: keep the
-    # canonical required-check name only when gate.run=true.
-    name: zephyr CI${{ needs.gate.outputs.run != 'true' && ' (non-required)' || '' }}
-    # `always()` is mandatory: on approval-triggered runs this job must run
-    # and fail when any dependency failed (a skipped job counts as passing for
-    # a required check). Only an upstream push is exempt - the gate already
-    # resolved to run=false there, every dependency is skipped, and skipping
-    # this job too keeps the whole push run uniformly "did not run".
-    if: always() && !(github.event_name == 'push' && github.event.repository.fork == false)
+    name: >-
+      ${{ needs.gate.outputs.state == 'push' && 'zephyr CI on push'
+      || needs.gate.outputs.state == 'awaiting' && 'zephyr CI awaiting approval'
+      || needs.gate.outputs.state == 'approved' && 'zephyr CI approved'
+      || 'zephyr CI' }}
+    if: always() && needs.gate.outputs.run == 'true'
     needs: [gate, smoke_test]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -4,7 +4,7 @@
 # Reusable gate shared by every upstream CI workflow. Callers invoke it via
 # `uses:` and gate their real jobs on `needs.gate.outputs.run`. Per event:
 #   - push: runs only on a fork, so upstream never spends minutes on a plain
-#     push; contributors still get CI on their own fork's branches.
+#     push; upstream push workflows still run the no-op gate to report status.
 #   - pull_request_review (submitted): only the first approval of a PR runs CI
 #     for the head SHA (repo policy allows exactly one approval). It is the
 #     authoritative CI trigger and is never deduplicated away: a prior
@@ -32,6 +32,9 @@ on:
       run:
         description: '"true" if downstream jobs should run, else "false".'
         value: ${{ jobs.gate.outputs.run }}
+      state:
+        description: 'Gate state used to select the stable check name.'
+        value: ${{ jobs.gate.outputs.state }}
 
 permissions:
   # `actions: read` lets the dedup query below list this workflow's own runs.
@@ -44,6 +47,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       run: ${{ steps.g.outputs.run }}
+      state: ${{ steps.g.outputs.state }}
     steps:
       # A local composite action needs the repo checked out before it can be
       # referenced; fetch just .github (also carries the path-filter helper).
@@ -63,8 +67,10 @@ jobs:
           set -eo pipefail
           set_run() {
             local run="$1"
-            local message="$2"
+            local state="$2"
+            local message="$3"
             echo "run=$run" >> "$GITHUB_OUTPUT"
+            echo "state=$state" >> "$GITHUB_OUTPUT"
             echo "::notice title=approval gate::$message"
           }
 
@@ -72,9 +78,9 @@ jobs:
           # approval-gated review path below.
           if [ "${{ github.event_name }}" = "push" ]; then
             if [ "${{ github.event.repository.fork }}" = "true" ]; then
-              set_run true "running CI for fork push"
+              set_run true push "running CI for fork push"
             else
-              set_run false "skipping CI for upstream push; approval triggers CI"
+              set_run false push "skipping CI for upstream push; approval triggers CI"
             fi
             exit 0
           fi
@@ -84,13 +90,13 @@ jobs:
           # directly and let downstream jobs decide as usual.
           if [ "${{ github.event_name }}" != "pull_request_review" ] \
              && [ "${{ github.event_name }}" != "pull_request" ]; then
-            set_run true "running CI for ${{ github.event_name }} event"
+            set_run true run "running CI for ${{ github.event_name }} event"
             exit 0
           fi
 
           if [ "${{ github.event_name }}" = "pull_request_review" ] \
              && [ "${{ github.event.review.state }}" != "approved" ]; then
-            set_run false "skipping CI because the review is not an approval"
+            set_run false awaiting "skipping CI because the review is not an approval"
             exit 0
           fi
 
@@ -103,7 +109,7 @@ jobs:
             n=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
                 --jq '[.[]|select(.state=="APPROVED")]|length')
             if [ "$n" -gt 1 ]; then
-              set_run false "skipping CI because this is not the first approval"
+              set_run false approved "skipping CI because this is not the first approval"
               exit 0
             fi
           fi
@@ -119,7 +125,7 @@ jobs:
                 -F number="${{ github.event.pull_request.number }}" \
                 --jq '.data.repository.pullRequest.reviewDecision // "REVIEW_REQUIRED"')
             if [ "$decision" != "APPROVED" ]; then
-              set_run false "waiting for approval of this synchronized SHA"
+              set_run false awaiting "waiting for approval of this synchronized SHA"
               exit 0
             fi
           fi
@@ -147,7 +153,7 @@ jobs:
             touches_paths=false
           fi
           if [ "$touches_paths" != "true" ]; then
-            set_run false "skipping CI because the PR does not touch relevant paths"
+            set_run false skipped "skipping CI because the PR does not touch relevant paths"
             exit 0
           fi
 
@@ -170,8 +176,8 @@ jobs:
                        | select(.conclusion == null or .conclusion == "success")
                      ] | length')
             if [ "$prior" -gt 0 ]; then
-              set_run false "skipping CI because ${{ github.event.pull_request.head.sha }} already has a run"
+              set_run false skipped "skipping CI because ${{ github.event.pull_request.head.sha }} already has a run"
               exit 0
             fi
           fi
-          set_run true "running CI for approved relevant PR SHA ${{ github.event.pull_request.head.sha }}"
+          set_run true run "running CI for approved relevant PR SHA ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -17,6 +17,13 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
+    # Keep fork push execution limited to changes relevant to the nightly
+    # pipeline. The same paths are passed to the approval gate below because
+    # pull_request_review does not support this push filter.
+    paths:
+      - ".github/workflows/nightly_run.yml"
+      - ".github/workflows/unit_test.yml"
+      - "core/iwasm/libraries/lib-wasi-threads/stress-test/**"
   # Upstream CI: on the first approval, re-run once - but only when the PR
   # changed the nightly pipeline itself (gate.paths below). Regular source
   # changes are covered by the nightly cron, not per-PR.
@@ -76,6 +83,7 @@ jobs:
     with:
       paths: |
         .github/workflows/nightly_run.yml
+        .github/workflows/unit_test.yml
         core/iwasm/libraries/lib-wasi-threads/stress-test/**
 
   nightly_guard:

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -17,12 +17,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    # running nightly pipeline if you're changing it
-    # stress tests are run only in nightly at the moment, so running them in they are changed
-    paths:
-      - ".github/workflows/nightly_run.yml"
-      - ".github/workflows/unit_test.yml"
-      - "core/iwasm/libraries/lib-wasi-threads/stress-test/**"
   # Upstream CI: on the first approval, re-run once - but only when the PR
   # changed the nightly pipeline itself (gate.paths below). Regular source
   # changes are covered by the nightly cron, not per-PR.

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -83,8 +83,11 @@ jobs:
     with:
       paths: |
         .github/workflows/nightly_run.yml
+        .github/workflows/gate.yml
         .github/workflows/unit_test.yml
         core/iwasm/libraries/lib-wasi-threads/stress-test/**
+        .github/actions/**
+        .github/scripts/**
 
   nightly_guard:
     needs: gate

--- a/.github/workflows/spec_test_on_nuttx.yml
+++ b/.github/workflows/spec_test_on_nuttx.yml
@@ -17,15 +17,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    paths:
-      - ".github/workflows/spec_test_on_nuttx.yml"
-      - "core/**"
-      - "!core/deps/**"
-      - "product-mini/**"
-      - "!samples/workload/**"
-      - "tests/wamr-test-suites/**"
-      - "wamr-compiler/**"
-      - "wamr-sdk/**"
   # Upstream CI: only spend upstream minutes once a PR is approved
   # (first approval only, enforced by the gate job below).
   pull_request_review:
@@ -63,6 +54,16 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
+    with:
+      paths: |
+        .github/workflows/spec_test_on_nuttx.yml
+        core/**
+        !core/deps/**
+        product-mini/**
+        !samples/workload/**
+        tests/wamr-test-suites/**
+        wamr-compiler/**
+        wamr-sdk/**
   build_llvm_libraries:
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}

--- a/.github/workflows/spec_test_on_nuttx.yml
+++ b/.github/workflows/spec_test_on_nuttx.yml
@@ -56,11 +56,14 @@ jobs:
     uses: ./.github/workflows/gate.yml
     with:
       paths: |
+        .github/scripts/install_qemu_xtensa.sh
+        .github/workflows/build_llvm_libraries.yml
+        .github/workflows/gate.yml
         .github/workflows/spec_test_on_nuttx.yml
         core/**
         !core/deps/**
-        product-mini/**
-        !samples/workload/**
+        product-mini/platforms/common/**
+        product-mini/platforms/nuttx/**
         tests/wamr-test-suites/**
         wamr-compiler/**
         wamr-sdk/**

--- a/.github/workflows/wamr_wasi_extensions.yml
+++ b/.github/workflows/wamr_wasi_extensions.yml
@@ -53,7 +53,8 @@ jobs:
     with:
       paths: |
         .github/workflows/wamr_wasi_extensions.yml
-        wamr_wasi_extensios/**
+        .github/workflows/gate.yml
+        wamr-wasi-extensions/**
         core/iwasm/libraries/wasi-nn/include/**
         core/iwasm/libraries/lib-socket/**
   build_wamr_wasi_extensions:

--- a/.github/workflows/wamr_wasi_extensions.yml
+++ b/.github/workflows/wamr_wasi_extensions.yml
@@ -17,11 +17,6 @@ on:
       - "main"
       - "release/**"
       - "dev/**"
-    paths:
-      - ".github/workflows/wamr_wasi_extensions.yml"
-      - "wamr_wasi_extensios/**"
-      - "core/iwasm/libraries/wasi-nn/include/**"
-      - "core/iwasm/libraries/lib-socket/**"
   # Upstream CI: only spend upstream minutes once a PR is approved
   # (first approval only, enforced by the gate job below).
   pull_request_review:
@@ -55,6 +50,12 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/gate.yml
+    with:
+      paths: |
+        .github/workflows/wamr_wasi_extensions.yml
+        wamr_wasi_extensios/**
+        core/iwasm/libraries/wasi-nn/include/**
+        core/iwasm/libraries/lib-socket/**
   build_wamr_wasi_extensions:
     needs: gate
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' }}


### PR DESCRIPTION
 - Fix an issue where a PR modifying only files filtered out by a workflow’s  paths  filter would not trigger the workflow, leaving required checks absent and blocking the merge.
 - Move path filtering from workflow triggers into the shared  gate.yml , ensuring approval and synchronization events always run the gate and report an explicit check status.
 - Standardize required check names across platform workflows, preventing approval-waiting, duplicate-approval, and push scenarios from incorrectly producing the canonical required check.
 - Make PR CI check out  refs/pull/<number>/merge  so it validates the projected merge result; add the  pr_ref  input to the affected reusable workflows.
 - Apply the same gate model to Windows, macOS, Android, SGX, Zephyr, NuttX, WASI extensions, CodeQL, nightly, and Coding Guidelines workflows
 - Add  .github/workflows/README.md  documenting the CI gate, ruleset, and status matrix