### PR TITLE
Fix ubuntu CI required check naming

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,20 +12,21 @@ This document specifies the GitHub Actions workflow triggers, approval gates, an
 | **Status Check Enforcement** | Requires canonical status checks to pass before merging. Current mandatory gates: `ubuntu CI` and `coding guidelines`. |
 | **Merge Queue**              | **Disabled** (standard PR merge flow).                                                                                 |
 
-> ℹ️ **Note on Check Evaluation:** GitHub evaluates required checks by their **exact check-run name**. A status of `skipped` is treated as passing by GitHub rulesets, allowing path-filtered and gated runs to satisfy merge requirements without executing redundant compute jobs.
+> ℹ️ **Note on Check Evaluation:** GitHub evaluates required checks by their **exact check-run name**. The aggregation job always runs after the gate has a decision so dynamic check names are evaluated before GitHub publishes the check run; `state=skipped` falls through to the canonical required check name while the expensive jobs underneath stay skipped.
 
 ### ⚙️ CI Approval & Execution Logic
 
 Real upstream CI execution is strictly **approval-gated** to optimize runner resources and enhance security:
 
-| Operational State                                  | Upstream CI Behavior                                                        | Canonical Check Name / Status                                 |
+| Operational State                                  | Upstream CI Behavior                                                        | Check Name / Status                                           |
 | -------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------- |
 | **PR Lifecycle Events** (`opened` / `reopened`)    | Real CI is **not** triggered.                                               | None (awaits review).                                         |
 | **Initial Review Approval**                        | Triggers full CI on the approved `head SHA` if relevant files are modified. | `ubuntu CI` (`success` / `failure`)                           |
 | **PR Sync with Valid Approval**                    | Triggers full CI only if approval remains active on the new commit.         | `ubuntu CI` (`success` / `failure`)                           |
-| **PR Sync without Approval / Non-Approval Review** | No expensive compute triggered.                                             | Non-required check `ubuntu CI awaiting approval` (`skipped`). |
-| **Approved PR without Relevant Changes**           | Path filtering bypasses test jobs.                                          | `ubuntu CI` (`skipped`).                                      |
-| **Duplicate Approval on Same SHA**                 | Bypasses redundant CI execution.                                            | Non-required check `ubuntu CI approved` (`skipped`).          |
+| **PR Sync without Approval / Non-Approval Review** | No expensive compute triggered.                                             | Non-required check `ubuntu CI awaiting approval` (`success`). |
+| **Approved PR without Relevant Changes**           | Path filtering bypasses test jobs.                                          | `ubuntu CI` (`success`).                                      |
+| **Duplicate Approval on Same SHA**                 | Bypasses redundant CI execution.                                            | Non-required check `ubuntu CI approved` (`success`).          |
+| **Duplicate Sync Run on Same SHA**                 | Bypasses redundant CI execution.                                            | `ubuntu CI` (`success`).                                      |
 
 #### Ref Resolution & Invalidation Rules
 
@@ -40,4 +41,4 @@ Push workflows apply differentiated execution paths based on repository origin a
 | ------------------- | ------------------------------ | --------------------------------------- | ------------------------------------------- |
 | **Branch Filtered** | `main`, `release/**`, `dev/**` | Workflow skipped via `branches-ignore`. | No check produced.                          |
 | **Fork Push**       | Non-filtered branches          | Executes full CI matrix.                | `ubuntu CI on push` (`success` / `failure`) |
-| **Upstream Push**   | Non-filtered branches          | Gate job skips expensive execution.     | `ubuntu CI on push` (`skipped`)             |
+| **Upstream Push**   | Non-filtered branches          | Gate job skips expensive execution.     | `ubuntu CI on push` (`success`)             |

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -196,10 +196,10 @@ jobs:
       || needs.gate.outputs.state == 'awaiting' && 'coding guidelines awaiting approval'
       || needs.gate.outputs.state == 'approved' && 'coding guidelines approved'
       || 'coding guidelines' }}
-    # `always()` is mandatory when this job is expected to run: it must fail
-    # when any dependency failed. Waiting/duplicate-approval states are
-    # intentionally skipped with their non-required names.
-    if: always() && needs.gate.outputs.run == 'true'
+    # `always()` keeps this aggregation check running even when upstream jobs
+    # fail or are skipped, so GitHub evaluates the dynamic check name and the
+    # script below can decide whether the workflow should pass.
+    if: always()
     needs: [gate, changes, compliance_job, actionlint, hadolint]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/compilation_on_android.yml
+++ b/.github/workflows/compilation_on_android.yml
@@ -159,7 +159,10 @@ jobs:
       || needs.gate.outputs.state == 'awaiting' && 'android CI awaiting approval'
       || needs.gate.outputs.state == 'approved' && 'android CI approved'
       || 'android CI' }}
-    if: always() && needs.gate.outputs.run == 'true'
+    # `always()` keeps this aggregation check running even when upstream jobs
+    # fail or are skipped, so GitHub evaluates the dynamic check name and the
+    # script below can decide whether the workflow should pass.
+    if: always()
     needs: [gate, build_iwasm]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -499,16 +499,18 @@ jobs:
   # upstream job fails, and a skipped job counts as passing for a required
   # check - it would be a gate that is green forever.
   #
-  # `skipped` must count as success: when the gate resolves to run=false (the
-  # PR does not touch this workflow's paths, or it is not the first approval)
-  # every job below is skipped, and that is the normal path.
+  # `skipped` must count as success: when the gate resolves to run=false, every
+  # job below is skipped, and that is the normal path.
   required:
     name: >-
       ${{ needs.gate.outputs.state == 'push' && 'macos CI on push'
       || needs.gate.outputs.state == 'awaiting' && 'macos CI awaiting approval'
       || needs.gate.outputs.state == 'approved' && 'macos CI approved'
       || 'macos CI' }}
-    if: always() && needs.gate.outputs.run == 'true'
+    # `always()` keeps this aggregation check running even when upstream jobs
+    # fail or are skipped, so GitHub evaluates the dynamic check name and the
+    # script below can decide whether the workflow should pass.
+    if: always()
     needs:
       [
         gate,

--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -234,16 +234,18 @@ jobs:
   # upstream job fails, and a skipped job counts as passing for a required
   # check - it would be a gate that is green forever.
   #
-  # `skipped` must count as success: when the gate resolves to run=false (the
-  # PR does not touch this workflow's paths, or it is not the first approval)
-  # every job below is skipped, and that is the normal path.
+  # `skipped` must count as success: when the gate resolves to run=false, every
+  # job below is skipped, and that is the normal path.
   required:
     name: >-
       ${{ needs.gate.outputs.state == 'push' && 'nuttx CI on push'
       || needs.gate.outputs.state == 'awaiting' && 'nuttx CI awaiting approval'
       || needs.gate.outputs.state == 'approved' && 'nuttx CI approved'
       || 'nuttx CI' }}
-    if: always() && needs.gate.outputs.run == 'true'
+    # `always()` keeps this aggregation check running even when upstream jobs
+    # fail or are skipped, so GitHub evaluates the dynamic check name and the
+    # script below can decide whether the workflow should pass.
+    if: always()
     needs: [gate, build_bloaty, build_iwasm_on_nuttx]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -341,16 +341,18 @@ jobs:
   # upstream job fails, and a skipped job counts as passing for a required
   # check - it would be a gate that is green forever.
   #
-  # `skipped` must count as success: when the gate resolves to run=false (the
-  # PR does not touch this workflow's paths, or it is not the first approval)
-  # every job below is skipped, and that is the normal path.
+  # `skipped` must count as success: when the gate resolves to run=false, every
+  # job below is skipped, and that is the normal path.
   required:
     name: >-
       ${{ needs.gate.outputs.state == 'push' && 'sgx CI on push'
       || needs.gate.outputs.state == 'awaiting' && 'sgx CI awaiting approval'
       || needs.gate.outputs.state == 'approved' && 'sgx CI approved'
       || 'sgx CI' }}
-    if: always() && needs.gate.outputs.run == 'true'
+    # `always()` keeps this aggregation check running even when upstream jobs
+    # fail or are skipped, so GitHub evaluates the dynamic check name and the
+    # script below can decide whether the workflow should pass.
+    if: always()
     needs: [gate, build_llvm_libraries, build_iwasm, run_samples_file, spec_test_default]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/compilation_on_ubuntu.yml
+++ b/.github/workflows/compilation_on_ubuntu.yml
@@ -794,23 +794,22 @@ jobs:
   # upstream job fails, and a skipped job counts as passing for a required
   # check - it would be a gate that is green forever.
   #
-  # `skipped` must count as success: when the gate resolves to run=false (the
-  # PR does not touch this workflow's paths, or it is not the first approval)
-  # every job below is skipped, and that is the normal path.
+  # `skipped` must count as success: when the gate resolves to run=false, every
+  # job below is skipped, and that is the normal path.
   required:
     # `name:` doubles as the check run name, which is what the ruleset's
-    # required_status_checks matches. Waiting and duplicate-approval states
-    # use non-required aliases; an approved path skip keeps canonical
-    # "ubuntu CI" and is itself skipped.
+    # required_status_checks matches. This job must run whenever the gate has a
+    # decision so GitHub evaluates the dynamic name instead of publishing the raw
+    # expression as the check name.
     name: >-
       ${{ needs.gate.outputs.state == 'push' && 'ubuntu CI on push'
       || needs.gate.outputs.state == 'awaiting' && 'ubuntu CI awaiting approval'
       || needs.gate.outputs.state == 'approved' && 'ubuntu CI approved'
       || 'ubuntu CI' }}
-    # `always()` is mandatory when this job is expected to run: it must fail
-    # when any dependency failed. Waiting/duplicate-approval states are
-    # intentionally skipped with their non-required names.
-    if: always() && needs.gate.outputs.run == 'true'
+    # `always()` is mandatory: it keeps this aggregation check running even when
+    # upstream jobs fail or are skipped, so the script below can decide whether
+    # the workflow should pass.
+    if: always()
     needs:
       [
         gate,

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -223,16 +223,18 @@ jobs:
   # upstream job fails, and a skipped job counts as passing for a required
   # check - it would be a gate that is green forever.
   #
-  # `skipped` must count as success: when the gate resolves to run=false (the
-  # PR does not touch this workflow's paths, or it is not the first approval)
-  # every job below is skipped, and that is the normal path.
+  # `skipped` must count as success: when the gate resolves to run=false, every
+  # job below is skipped, and that is the normal path.
   required:
     name: >-
       ${{ needs.gate.outputs.state == 'push' && 'windows CI on push'
       || needs.gate.outputs.state == 'awaiting' && 'windows CI awaiting approval'
       || needs.gate.outputs.state == 'approved' && 'windows CI approved'
       || 'windows CI' }}
-    if: always() && needs.gate.outputs.run == 'true'
+    # `always()` keeps this aggregation check running even when upstream jobs
+    # fail or are skipped, so GitHub evaluates the dynamic check name and the
+    # script below can decide whether the workflow should pass.
+    if: always()
     needs:
       [
         gate,

--- a/.github/workflows/compilation_on_zephyr.yml
+++ b/.github/workflows/compilation_on_zephyr.yml
@@ -188,16 +188,18 @@ jobs:
   # upstream job fails, and a skipped job counts as passing for a required
   # check - it would be a gate that is green forever.
   #
-  # `skipped` must count as success: when the gate resolves to run=false (the
-  # PR does not touch this workflow's paths, or it is not the first approval)
-  # every job below is skipped, and that is the normal path.
+  # `skipped` must count as success: when the gate resolves to run=false, every
+  # job below is skipped, and that is the normal path.
   required:
     name: >-
       ${{ needs.gate.outputs.state == 'push' && 'zephyr CI on push'
       || needs.gate.outputs.state == 'awaiting' && 'zephyr CI awaiting approval'
       || needs.gate.outputs.state == 'approved' && 'zephyr CI approved'
       || 'zephyr CI' }}
-    if: always() && needs.gate.outputs.run == 'true'
+    # `always()` keeps this aggregation check running even when upstream jobs
+    # fail or are skipped, so GitHub evaluates the dynamic check name and the
+    # script below can decide whether the workflow should pass.
+    if: always()
     needs: [gate, smoke_test]
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
The ubuntu required aggregation job used a dynamic name expression, but it was guarded by needs.gate.outputs.run == 'true'. When the gate skipped Ubuntu CI for unrelated paths such as Zephyr files, GitHub skipped the aggregation job before evaluating the dynamic name and published the raw expression as the check name instead of ubuntu CI.

Run the aggregation job with always() so GitHub evaluates the name in every gate decision path while the script still treats skipped dependencies as successful and reports real dependency failures.