### PR TITLE
aot: check SIMD compatibility against the real target machine

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -3421,20 +3421,9 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
     }
 
     if (option->enable_simd) {
-        char *tmp;
-        bool check_simd_ret;
-
         comp_ctx->enable_simd = true;
 
-        if (!(tmp = LLVMGetTargetMachineCPU(comp_ctx->target_machine))) {
-            aot_set_last_error("get CPU from Target Machine fail");
-            goto fail;
-        }
-
-        check_simd_ret =
-            aot_check_simd_compatibility(comp_ctx->target_arch, tmp);
-        LLVMDisposeMessage(tmp);
-        if (!check_simd_ret) {
+        if (!aot_check_simd_compatibility(comp_ctx->target_machine)) {
             aot_set_last_error("SIMD compatibility check failed, "
                                "try adding --cpu=<cpu> to specify a cpu "
                                "or adding --disable-simd to disable SIMD");

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -652,7 +652,7 @@ aot_load_const_from_table(AOTCompContext *comp_ctx, LLVMValueRef base,
                           const WASMValue *value, uint8 value_type);
 
 bool
-aot_check_simd_compatibility(const char *arch_c_str, const char *cpu_c_str);
+aot_check_simd_compatibility(LLVMTargetMachineRef target_machine);
 
 void
 aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx, LLVMModuleRef module);

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -77,7 +77,7 @@ using Optional = std::optional<T>;
 LLVM_C_EXTERN_C_BEGIN
 
 bool
-aot_check_simd_compatibility(const char *arch_c_str, const char *cpu_c_str);
+aot_check_simd_compatibility(LLVMTargetMachineRef target_machine);
 
 void
 aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx, LLVMModuleRef module);
@@ -146,45 +146,39 @@ ExpandMemoryOpPass::run(Function &F, FunctionAnalysisManager &AM)
 }
 
 bool
-aot_check_simd_compatibility(const char *arch_c_str, const char *cpu_c_str)
+aot_check_simd_compatibility(LLVMTargetMachineRef target_machine)
 {
 #if WASM_ENABLE_SIMD != 0
-    if (!arch_c_str || !cpu_c_str) {
+    if (!target_machine) {
         return false;
     }
 
-    llvm::SmallVector<std::string, 1> targetAttributes;
-    llvm::Triple targetTriple(arch_c_str, "", "");
-    auto targetMachine =
-        std::unique_ptr<llvm::TargetMachine>(llvm::EngineBuilder().selectTarget(
-            targetTriple, "", std::string(cpu_c_str), targetAttributes));
-    if (!targetMachine) {
-        return false;
-    }
-
-    const llvm::Triple::ArchType targetArch =
-        targetMachine->getTargetTriple().getArch();
+    /* Query the target machine that will actually be used for code
+       generation. Re-deriving a subtarget from the CPU name alone would
+       drop the feature string, and a CPU name unknown to this LLVM version
+       falls back to "generic", which advertises no SIMD feature even when
+       the host does support it. */
+    const llvm::TargetMachine *targetMachine =
+        reinterpret_cast<llvm::TargetMachine *>(target_machine);
     const llvm::MCSubtargetInfo *subTargetInfo =
         targetMachine->getMCSubtargetInfo();
     if (subTargetInfo == nullptr) {
         return false;
     }
 
-    if (targetArch == llvm::Triple::x86_64) {
-        return subTargetInfo->checkFeatures("+sse4.1");
-    }
-    else if (targetArch == llvm::Triple::aarch64) {
-        return subTargetInfo->checkFeatures("+neon");
-    }
-    else if (targetArch == llvm::Triple::arc) {
-        return true;
-    }
-    else {
-        return false;
+    switch (targetMachine->getTargetTriple().getArch()) {
+        case llvm::Triple::x86_64:
+            return subTargetInfo->checkFeatures("+sse4.1");
+        case llvm::Triple::aarch64:
+        case llvm::Triple::aarch64_be:
+            return subTargetInfo->checkFeatures("+neon");
+        case llvm::Triple::arc:
+            return true;
+        default:
+            return false;
     }
 #else
-    (void)arch_c_str;
-    (void)cpu_c_str;
+    (void)target_machine;
     return true;
 #endif /* WASM_ENABLE_SIMD */
 }


### PR DESCRIPTION
aot_check_simd_compatibility() only received the CPU name, and rebuilt a throwaway subtarget from it with an empty feature string. The verdict therefore depended entirely on whether LLVM recognizes the CPU model.

sys::getHostCPUName() falls back to "generic" when it cannot identify the host. The AMD branch has no feature-based degradation path (unlike Intel family 6), so any AMD family newer than what LLVM knows -- e.g. Zen 5 (family 1Ah) on LLVM 18, which only covers up to 19h -- lands on that fallback. "generic" is defined as [X87, CX8, X86_64] and advertises no SSE4.1, so the check failed and SIMD modules were rejected on hosts that do support SIMD.

It was a false negative: LLVMGetHostCPUFeatures() reads CPUID directly, is unaffected by model recognition, and was already handed to the real target machine -- codegen would have emitted correct SSE4.1 code. Only the check, which discarded that string, disagreed.

Query the target machine that is actually used for code generation instead. Its feature set is decoupled from CPU model recognition, and the arch now comes from the same triple rather than a separate string compare. This covers both the LLVM JIT and the AOT path, which derive cpu/features identically.

--cpu-features is now honored by the check as well; it was previously dropped.