### PR TITLE
samples/wasm-c-api-imports: switch to wasi-threads

### DIFF
--- a/doc/pthread_impls.md
+++ b/doc/pthread_impls.md
@@ -19,6 +19,25 @@ In future, we might remove the old implementation.
 
   * WAMR-specific ABI
 
+  * **It requires the wasm module NOT to link the pthread implementation of
+    wasi-libc.** The `pthread_*` symbols have to stay undefined at link time so
+    that they end up as `env.pthread_*` imports, which WAMR then resolves.
+    Starting from
+    [wasi-sdk 26](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-26),
+    `libc.a` of the plain `wasm32-wasi` target defines `pthread_create` and
+    friends itself (in wasi-sdk 25 and earlier they only lived in
+    `libwasi-emulated-pthread.a`, which is not linked by default). The linker
+    then prefers those definitions, no `env.pthread_*` import is emitted, and
+    WAMR lib-pthread is silently bypassed: at runtime `pthread_create()` fails
+    without setting `errno`, so `perror()` prints a confusing
+    `... failed: Success`.
+
+    So keep building against the WAMR builtin libc sysroot
+    (`-nostdlib --sysroot=${WAMR_ROOT}/wamr-sdk/app/libc-builtin-sysroot`, see
+    [samples/multi-thread](../samples/multi-thread)), which is unaffected by the
+    wasi-sdk version. If the module needs wasi-libc (for WASI file or socket
+    APIs), use wasi-threads instead of mixing the two.
+
   * [Known limitations](pthread_library.md#known-limits)
 
 ## wasi-threads (new)

--- a/doc/pthread_library.md
+++ b/doc/pthread_library.md
@@ -58,6 +58,15 @@ To build this C program into WebAssembly app with libc-builtin, you can use this
 
 **Build with libc-WASI**
 
+> **Warning**: This way of building works with wasi-sdk 25 and earlier only.
+> Since [wasi-sdk 26](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-26),
+> `libc.a` of the `wasm32-wasi` target defines `pthread_create` and friends by
+> itself, so the linker no longer emits the `env.pthread_*` imports this library
+> relies on. The module still builds and loads, but WAMR lib-pthread is bypassed
+> and `pthread_create()` fails at runtime without setting `errno` (`perror()`
+> prints `... failed: Success`). If your module has to link wasi-libc, use
+> [wasi-threads](pthread_impls.md#wasi-threads-new) instead.
+
 You can also build this program with WASI, but we need to make some changes to wasi-sysroot:
 
 1. disable malloc/free of wasi, as they are not atomic operations:

--- a/samples/wasm-c-api-imports/.gitignore
+++ b/samples/wasm-c-api-imports/.gitignore
@@ -1,2 +1,0 @@
-/wasm/inc/**
-!/wasm/inc/.*

--- a/samples/wasm-c-api-imports/CMakeLists.txt
+++ b/samples/wasm-c-api-imports/CMakeLists.txt
@@ -13,13 +13,6 @@ include(FetchContent)
 # dependencies
 #
 set(WAMR_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../)
-# wasm required headers
-execute_process(
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-              ${WARM_ROOT}/${WAMR_ROOT}/wamr-sdk/app/libc-builtin-sysroot/include/pthread.h
-              ${CMAKE_CURRENT_LIST_DIR}/wasm/inc
-)
-
 # vmlib
 ################  runtime settings  ################
 string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
@@ -66,8 +59,8 @@ if (NOT DEFINED WAMR_BUILD_INTERP)
 endif ()
 set(WAMR_BUILD_JIT 0)
 set(WAMR_BUILD_FAST_INTERP 1)
-set(WAMR_BUILD_LIB_PTHREAD 1)
-set(WAMR_BUILD_LIBC_BUILTIN 1)
+set(WAMR_BUILD_LIB_WASI_THREADS 1)
+set(WAMR_BUILD_LIBC_BUILTIN 0)
 set(WAMR_BUILD_LIBC_WASI 1)
 set(WAMR_BUILD_SIMD 0)
 # wamrc emits reference types by default, so the runtime must enable them to
@@ -128,7 +121,7 @@ add_custom_target(
 list(APPEND CMAKE_MODULE_PATH ${WAMR_ROOT}/build-scripts)
 find_package(WASISDK REQUIRED)
 set(WASI_SDK_DIR ${WASISDK_HOME})
-set(WASI_TOOLCHAIN_FILE ${WASISDK_TOOLCHAIN})
+set(WASI_TOOLCHAIN_FILE ${WASISDK_PTHREAD_TOOLCHAIN})
 set(WASI_SYS_ROOT ${WASISDK_SYSROOT})
 
 #

--- a/samples/wasm-c-api-imports/README.md
+++ b/samples/wasm-c-api-imports/README.md
@@ -14,25 +14,26 @@ WASM_API_EXTERN own wasm_instance_t* wasm_instance_new(
 import section_ of a .wasm.
 
 ```bash
-$ /opt/wabt-1.0.31/bin/wasm-objdump -j Import -x <some_example>.wasm
+$ /opt/wabt/bin/wasm-objdump -j Import -x <some_example>.wasm
 
 Section Details:
 
-Import[27]:
- - func[0] sig=2 <pthread_mutex_lock> <- env.pthread_mutex_lock
- - func[1] sig=2 <pthread_mutex_unlock> <- env.pthread_mutex_unlock
- - func[2] sig=2 <pthread_cond_signal> <- env.pthread_cond_signal
- - func[3] sig=3 <host_log> <- env.log
+Import[21]:
+ - memory[0] pages: initial=2 max=30 shared <- env.memory
+ - func[0] sig=4 <host_log> <- env.log
+ - func[1] sig=5 <__imported_wasi_snapshot_preview1_sock_bind> <- wasi_snapshot_preview1.sock_bind
+ - func[2] sig=5 <__imported_wasi_snapshot_preview1_sock_connect> <- wasi_snapshot_preview1.sock_connect
+ - func[3] sig=5 <__imported_wasi_snapshot_preview1_sock_listen> <- wasi_snapshot_preview1.sock_listen
+ - func[4] sig=6 <__imported_wasi_snapshot_preview1_sock_open> <- wasi_snapshot_preview1.sock_open
+ - func[5] sig=5 <__imported_wasi_snapshot_preview1_sock_addr_remote> <- wasi_snapshot_preview1.sock_addr_remote
+ - func[6] sig=5 <__imported_wasi_snapshot_preview1_args_get> <- wasi_snapshot_preview1.args_get
+ - func[7] sig=5 <__imported_wasi_snapshot_preview1_args_sizes_get> <- wasi_snapshot_preview1.args_sizes_get
  ...
- - func[11] sig=4 <__imported_wasi_snapshot_preview1_sock_bind> <- wasi_snapshot_preview1.sock_bind
- - func[12] sig=4 <__imported_wasi_snapshot_preview1_sock_connect> <- wasi_snapshot_preview1.sock_connect
- - func[13] sig=4 <__imported_wasi_snapshot_preview1_sock_listen> <- wasi_snapshot_preview1.sock_listen
- - func[14] sig=5 <__imported_wasi_snapshot_preview1_sock_open> <- wasi_snapshot_preview1.sock_open
- - func[15] sig=4 <__imported_wasi_snapshot_preview1_sock_addr_remote> <- wasi_snapshot_preview1.sock_addr_remote
- - func[16] sig=4 <__imported_wasi_snapshot_preview1_args_get> <- wasi_snapshot_preview1.args_get
- - func[17] sig=4 <__imported_wasi_snapshot_preview1_args_sizes_get> <- wasi_snapshot_preview1.args_sizes_get
- ...
+ - func[19] sig=2 <__imported_wasi_thread_spawn> <- wasi.thread-spawn
 ```
+
+Notice the import section is not only about functions. It may also contain
+memories, tables and globals, like the shared `env.memory` above.
 
 Developers should fill in _imports_ with enough host functions and make sure
 there are no linking problems during instantiation.
@@ -93,7 +94,8 @@ also not economical to code for those functions.
 Using module names as a filter seems to be a simple way. But some private
 additional c/c++ libraries are supported in WAMR. Those supporting will bring
 more import items that don't use `wasi_snapshot_preview1` as module names but are still
-covered by the WASM runtime. Like `env.pthread_`. Plus, [the native lib registration](https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/export_native_api.md)
+covered by the WASM runtime. Like `wasi.thread-spawn` of _wasi-threads_, or the
+shared `env.memory`. Plus, [the native lib registration](https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/export_native_api.md)
 provides another possible way to fill in the requirement of _the import section_.
 
 Let's take summarize. A proper `wasm_extern_vec_t *imports` should include:
@@ -113,11 +115,17 @@ The recommendation is:
 [wasm-c-api-imports](.) is a simple showcase of how to do that.
 
 First, let's take a look at the Wasm module. [send_recv](./wasm/send_recv.c)
-uses both standard WASI and WAMR_BUILD_LIB_PTHREAD supporting. Plus a private
-native function `host_log`.
+uses both standard WASI and WAMR_BUILD_LIB_WASI_THREADS supporting. Plus a
+private native function `host_log`.
+
+It is built with the _wasi-threads_ toolchain file of wasi-sdk
+(`share/cmake/wasi-sdk-pthread.cmake`), so `pthread_create()` of wasi-libc ends
+up in `wasi.thread-spawn`, which the runtime implements when
+`WAMR_BUILD_LIB_WASI_THREADS` is on.
 
 So, `wasm_extern_vec_t *imports` should only include the host implementation of
-`host_log` and avoid WASI related(`wasm-c-api-imports.XXX`) and pthread related(`env.pthread_XXX`).
+`host_log` and avoid WASI related(`wasi_snapshot_preview1.XXX`), threads
+related(`wasi.thread-spawn`) and the shared `env.memory`.
 
 [Here is how to do](./host/example1.c):
 

--- a/samples/wasm-c-api-imports/wasm/CMakeLists.txt
+++ b/samples/wasm-c-api-imports/wasm/CMakeLists.txt
@@ -18,12 +18,15 @@ endif()
 include(${SOCKET_WASI_CMAKE})
 add_executable(send_recv ${CMAKE_CURRENT_LIST_DIR}/send_recv.c)
 set_target_properties(send_recv PROPERTIES SUFFIX .wasm)
-target_include_directories(send_recv PUBLIC ${CMAKE_CURRENT_LIST_DIR}/inc)
+target_compile_options(send_recv PRIVATE -ftls-model=local-exec)
 target_link_libraries(send_recv socket_wasi_ext)
 target_link_options(send_recv PRIVATE
   LINKER:--export=__heap_base
   LINKER:--export=__data_end
-  LINKER:--shared-memory,--max-memory=196608
+  LINKER:--shared-memory,--max-memory=1966080
+  LINKER:--export=wasi_thread_start
+  LINKER:--export=malloc
+  LINKER:--export=free
   LINKER:--no-check-features
   LINKER:--allow-undefined
 )

--- a/samples/wasm-c-api-imports/wasm/send_recv.c
+++ b/samples/wasm-c-api-imports/wasm/send_recv.c
@@ -16,7 +16,7 @@
 #include <unistd.h>
 #ifdef __wasi__
 #include <wasi_socket_ext.h>
-#include "pthread.h"
+#include <pthread.h>
 #else
 #include <pthread.h>
 #endif


### PR DESCRIPTION
Since wasi-sdk 26, libc.a of the wasm32-wasi target defines pthread_create itself (before that it only lived in libwasi-emulated-pthread.a, which is not linked by default). The sample links wasi-libc for the WASI socket APIs and relied on --allow-undefined turning pthread_* into env.pthread_* imports, so the linker now silently resolves them locally, WAMR lib-pthread is never reached, and pthread_create() fails without setting errno -- "Create a server thread failed: Success", then exit(EXIT_FAILURE).

Build the wasm module with the wasi-sdk pthread toolchain file and enable WAMR_BUILD_LIB_WASI_THREADS instead. Verified with wasi-sdk 25 and 29.

Document the constraint in doc/pthread_impls.md and doc/pthread_library.md: lib-pthread requires the module not to link the pthread implementation of wasi-libc.