### PR TITLE
refactor: Add CFI directives to aarch64/riscv invokeNative

### DIFF
--- a/core/iwasm/common/arch/invokeNative_aarch64.s
+++ b/core/iwasm/common/arch/invokeNative_aarch64.s
@@ -4,6 +4,7 @@
  */
         .text
         .align  2
+        .cfi_sections .debug_frame
 #ifndef BH_PLATFORM_DARWIN
         .globl invokeNative
         .type  invokeNative, function
@@ -12,6 +13,7 @@ invokeNative:
         .globl _invokeNative
 _invokeNative:
 #endif /* end of BH_PLATFORM_DARWIN */
+        .cfi_startproc
 
 /*
  * Arguments passed in:
@@ -22,14 +24,22 @@ _invokeNative:
  */
 
         sub     sp, sp, #0x30
+        .cfi_def_cfa_offset 0x30
         stp     x19, x20, [sp, #0x20] /* save the registers */
+        .cfi_offset 19, -0x10
+        .cfi_offset 20, -0x08
         stp     x21, x22, [sp, #0x10]
+        .cfi_offset 21, -0x20
+        .cfi_offset 22, -0x18
         stp     x23, x24, [sp, #0x0]
+        .cfi_offset 23, -0x30
+        .cfi_offset 24, -0x28
 
         mov     x19, x0          /* x19 = function ptr */
         mov     x20, x1          /* x20 = argv */
         mov     x21, x2          /* x21 = nstacks */
         mov     x22, sp          /* save the sp before call function */
+        .cfi_def_cfa_register 22
 
         /* Fill in float-point registers */
         ldp     d0, d1, [x20], #16 /* d0 = argv[0], d1 = argv[1] */
@@ -68,16 +78,26 @@ loop_stack_args:                 /* copy stack arguments to stack */
 
 call_func:
         mov     x20, x30         /* save x30(lr) */
+        .cfi_register 30, 20
         blr     x19
         mov     sp, x22          /* restore sp which is saved before calling function*/
 
 return:
         mov     x30,  x20              /* restore x30(lr) */
+        .cfi_restore 30
         ldp     x19, x20, [sp, #0x20]  /* restore the registers in stack */
+        .cfi_restore 19
+        .cfi_restore 20
         ldp     x21, x22, [sp, #0x10]
+        .cfi_restore 21
+        .cfi_restore 22
         ldp     x23, x24, [sp, #0x0]
+        .cfi_restore 23
+        .cfi_restore 24
         add     sp, sp, #0x30          /* restore sp */
+        .cfi_def_cfa sp, 0
         ret
+        .cfi_endproc
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/core/iwasm/common/arch/invokeNative_riscv.S
+++ b/core/iwasm/common/arch/invokeNative_riscv.S
@@ -39,6 +39,7 @@
 
         .text
         .align  2
+        .cfi_sections .debug_frame
 #ifndef BH_PLATFORM_DARWIN
         .globl invokeNative
         .type  invokeNative, function
@@ -47,6 +48,7 @@ invokeNative:
         .globl _invokeNative
 _invokeNative:
 #endif /* end of BH_PLATFORM_DARWIN */
+        .cfi_startproc
 
 /*
  * Arguments passed in:
@@ -75,8 +77,12 @@ _invokeNative:
         addi             sp, sp, - 2 * RV_REG_SIZE
         RV_OP_STOREREG   fp, 0 * RV_REG_SIZE(sp)    /* save frame pointer */
         RV_OP_STOREREG   ra, 1 * RV_REG_SIZE(sp)    /* save return address */
+        .cfi_def_cfa_offset 2 * RV_REG_SIZE
+        .cfi_offset s0, -2 * RV_REG_SIZE
+        .cfi_offset ra, -1 * RV_REG_SIZE
 
         mv               fp, sp                     /* set frame pointer to bottom of fixed frame */
+        .cfi_def_cfa_register s0
 
         /* save function ptr, argv & nstacks */
         mv               t0, a0                     /* t0 = function ptr */
@@ -142,7 +148,12 @@ call_func:
         /* restore registers pushed in stack or saved in another register */
 return:
         mv               sp, fp                     /* restore sp saved in fp before function call */
+        .cfi_def_cfa_register sp
         RV_OP_LOADREG    fp, 0 * RV_REG_SIZE(sp)    /* load previous frame pointer to fp register */
+        .cfi_restore s0
         RV_OP_LOADREG    ra, 1 * RV_REG_SIZE(sp)    /* load previous return address to ra register */
+        .cfi_restore ra
         addi             sp, sp, 2 * RV_REG_SIZE    /* pop frame, restore sp */
+        .cfi_def_cfa_offset 0
         jr               ra
+        .cfi_endproc


### PR DESCRIPTION
Add CFI directives to `invokeNative_aarch64.s` and `invokeNative_riscv.S` for proper GDB backtrace

## Summary

Add DWARF Call Frame Information (CFI) directives to the AArch64 and RISC-V `invokeNative` assembly routines so that GDB can correctly unwind the call stack through the assembly boundary.

Without CFI annotations, GDB cannot determine how `invokeNative` manipulates the stack frame (saves/restores callee-saved registers and the return address), which causes the backtrace to stop prematurely at the assembly boundary.

This change mirrors what `invokeNative_thumb.s` already does for ARM Thumb targets (#4719), extending the same debug experience to the AArch64 and RISC-V (RV32/RV64) ports.

## Changes

### `core/iwasm/common/arch/invokeNative_aarch64.s`

- `.cfi_sections .debug_frame` — emit unwind info into `.debug_frame` so it survives final linking on platforms like NuttX, where `--gc-sections` discards `.eh_frame` for assembly objects.
- `.cfi_startproc` / `.cfi_endproc` — mark the CFI region.
- `.cfi_def_cfa_offset 0x30` / `.cfi_def_cfa_register 22` — track the Canonical Frame Address while `sp` is adjusted and then switched to the saved copy in `x22`.
- `.cfi_offset 19..24` — record where callee-saved registers (x19–x24) are spilled on the stack.
- `.cfi_register 30, 20` — tell the unwinder that `lr` (x30) is moved into `x20` around `blr x19`, then `.cfi_restore` for all registers in the epilogue.

### `core/iwasm/common/arch/invokeNative_riscv.S`

- `.cfi_sections .debug_frame`, `.cfi_startproc` / `.cfi_endproc` — same section and region handling as above.
- `.cfi_def_cfa_offset 2 * RV_REG_SIZE` / `.cfi_def_cfa_register s0` — CFA tracking with `s0` as frame pointer.
- `.cfi_offset s0` / `.cfi_offset ra` — record where callee-saved registers are spilled.
- `.cfi_restore s0` / `.cfi_restore ra` and CFA switch back to `sp` in the epilogue.

### No functional change

Both patches contain **assembler directives only** — no instruction is added, removed, or modified. Runtime behavior and performance are unchanged; the only difference in the build artifacts is the extra unwind information section.

## Testing

### AArch64 — QEMU arm64 virt + NuttX (classic interpreter + libc-builtin)

`iwasm` runs the test module normally:

```
nsh> iwasm /host/printf_test.wasm
Hello from WASM! n=42
```

Breaking at `printf_wrapper`, the backtrace now unwinds through `invokeNative_aarch64.s` into the full WAMR runtime call chain:

```
#0  printf_wrapper (exec_env=0x4042b350, format=0x404071c0 "Hello from WASM! n=%d\n", ...)
        at libc_builtin_wrapper.c:393
#1  0x000000004028133c in call_func () at invokeNative_aarch64.s:82
#2  0x00000000402bf43c in wasm_runtime_invoke_native (...) at wasm_runtime_common.c:6316
#3  0x00000000402c42f0 in wasm_interp_call_func_native (...) at wasm_interp_classic.c:1276
#4  0x00000000402c7b68 in wasm_interp_call_func_bytecode (...) at wasm_interp_classic.c:6716
#5  0x00000000402c7ea4 in wasm_interp_call_wasm (...) at wasm_interp_classic.c:7515
...
#11 iwasm_main (argc=2, argv=0x40404af8) at posix/main.c:1057
#12 0x0000000040297a40 in nxtask_startup (...) at task_startup.c:72
#13 0x0000000040293cb8 in nxtask_start () at task_start.c:104
```

The key technique is `.cfi_register 30, 20` at `mov x20, x30`: it tells GDB the return address (x30/LR) has been moved into `x20` before `blr x19`, so the unwinder can find it after the call.

### RISC-V — QEMU rv-virt (rv-virt:nsh) + NuttX (classic interpreter + libc-builtin)

`iwasm` runs the test module normally:

```
nsh> mount -t hostfs -o fs=/home/huang/Work/nx /host
nsh> iwasm /host/printf_test.wasm
Hello from WASM! n=42
```

**Before (without CFI)** — backtrace stopped at the assembly boundary:

```
#0  printf_wrapper (exec_env=0x800736b8, format=0x8004f5e0 "Hello from WASM! n=%d\n", ...)
        at libc_builtin_wrapper.c:394
#1  0x80000484 in call_func () at invokeNative_riscv.S:145
Backtrace stopped: frame did not save the PC
```

**After (with CFI)** — the complete call chain unwinds through `invokeNative_riscv.S`:

```
#0  printf_wrapper (exec_env=0x800736b8, ...) at libc_builtin_wrapper.c:394
#1  0x80000484 in call_func () at invokeNative_riscv.S:146
#2  0x800236e8 in wasm_runtime_invoke_native (...) at wasm_runtime_common.c:5656
#3  0x80026716 in wasm_interp_call_func_native (...) at wasm_interp_classic.c:1276
#4  0x80029f5c in wasm_interp_call_func_bytecode (...) at wasm_interp_classic.c:6716
#5  0x8002a1ce in wasm_interp_call_wasm (...) at wasm_interp_classic.c:7515
#6  0x80023f84 in wasm_call_function (...) at wasm_runtime.c:3710
#7  0x800230f0 in wasm_runtime_call_wasm (...) at wasm_runtime_common.c:2791
#8  0x800221ec in execute_main (...) at wasm_application.c:266
...
#11 iwasm_main (argc=2, argv=0x8004d128) at posix/main.c:1057
#12 0x8000a0b6 in nxtask_startup (entrypt=0x800129ba <iwasm_main>, ...) at task_startup.c:72
#13 0x800059b0 in nxtask_start () at task_start.c:104
```

Verification that the unwind info is present in the final linked ELF:

```
$ riscv-none-elf-readelf --debug-dump=frames-interp nuttx | grep -A4 '80000404'

0000ddc8 00000024 0000ddb8 FDE cie=0000ddb8 pc=80000404..8000048e
   LOC   CFA      ra    s0
80000404 sp+0     u     u
8000040a sp+8     c-4   c-8
8000040c s0+8     c-4   c-8
```